### PR TITLE
Add multiple rules per app

### DIFF
--- a/app/src/main/java/com/hilight/studio/AppRulesScreen.kt
+++ b/app/src/main/java/com/hilight/studio/AppRulesScreen.kt
@@ -78,7 +78,8 @@ fun AppRulesScreen(store: Store) {
         }
     }
 
-    rules.forEachIndexed { index, rule ->
+    rules.groupBy { it.pkg }.values.forEachIndexed { index, appRules ->
+        val app = appRules.first()
         // cards ease in rather than appearing, staggered down the list
         AnimatedVisibility(
             visible = true,
@@ -86,17 +87,16 @@ fun AppRulesScreen(store: Store) {
                 slideInVertically(spring(dampingRatio = Spring.DampingRatioLowBouncy)) { it / 6 } +
                 scaleIn(tween(240), initialScale = 0.97f),
         ) {
-            RuleCard(
-                rule = rule,
-                onToggle = { store.upsertRule(rule.copy(enabled = it)) },
-                onEdit = { editing = rule },
+            RuleGroupCard(
+                label = app.label,
+                rules = appRules,
+                onAdd = { editing = AppRule(pkg = app.pkg, label = app.label) },
+                onToggle = { rule, enabled -> store.upsertRule(rule.copy(enabled = enabled)) },
+                onEdit = { editing = it },
                 onTest = {
-                    // test what the rule will actually do, including how long it stays lit
-                    store.preview(
-                        rule.pattern, rule.color, rule.speedMs, rule.brightness, rule.durationMs,
-                    )
+                    store.preview(it.pattern, it.color, it.speedMs, it.brightness, it.durationMs)
                 },
-                onDelete = { store.removeRule(rule) },
+                onDelete = { store.removeRule(it) },
             )
         }
     }
@@ -125,65 +125,96 @@ fun AppRulesScreen(store: Store) {
 }
 
 @Composable
-private fun RuleCard(
-    rule: AppRule,
-    onToggle: (Boolean) -> Unit,
-    onEdit: () -> Unit,
-    onTest: () -> Unit,
-    onDelete: () -> Unit,
+private fun RuleGroupCard(
+    label: String,
+    rules: List<AppRule>,
+    onAdd: () -> Unit,
+    onToggle: (AppRule, Boolean) -> Unit,
+    onEdit: (AppRule) -> Unit,
+    onTest: (AppRule) -> Unit,
+    onDelete: (AppRule) -> Unit,
 ) {
     val haptics = LocalHapticFeedback.current
     PixelCard {
-        Row(
-            Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Row(
-                Modifier.fillMaxWidth(0.72f),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-            ) {
-                if (!rule.randomColor) {
-                    Box(
-                        Modifier
-                            .size(14.dp)
-                            .background(Color(rule.color), CircleShape)
+        SectionTitle(
+            label,
+            trailing = {
+                TextButton(onClick = onAdd) {
+                    Icon(Icons.Rounded.Add, contentDescription = null)
+                    Spacer(Modifier.width(4.dp))
+                    ButtonLabel("Add rule")
+                }
+            },
+        )
+        rules.forEach { rule ->
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Row(
+                    Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.Top,
+                ) {
+                    Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(3.dp)) {
+                        Text(rule.conditionLabel(), style = MaterialTheme.typography.bodyLarge)
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            if (rule.randomColor) {
+                                Caption("Random colour")
+                            } else {
+                                Box(
+                                    Modifier
+                                        .size(11.dp)
+                                        .background(Color(rule.color), CircleShape)
+                                )
+                                Spacer(Modifier.width(6.dp))
+                                Caption("Colour")
+                            }
+                            Spacer(Modifier.width(8.dp))
+                            Caption(
+                                rule.pattern.label + " · " +
+                                    if (rule.trigger == Trigger.NOTIFICATION) formatDuration(rule.durationMs)
+                                    else "until closed"
+                            )
+                        }
+                    }
+                    Switch(
+                        checked = rule.enabled,
+                        onCheckedChange = {
+                            haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                            onToggle(rule, it)
+                        },
                     )
                 }
-                Column {
-                    Text(rule.label, style = MaterialTheme.typography.titleMedium)
-                    Caption(
-                        (if (rule.randomColor) "Random colour" else rule.pattern.label) + " · " +
-                            if (rule.trigger == Trigger.NOTIFICATION) "on notification" else "while open"
-                    )
+                LedStrip(
+                    rule.pattern,
+                    Ambient(
+                        pattern = rule.pattern,
+                        color = rule.color,
+                        speedMs = rule.speedMs,
+                        brightness = rule.brightness,
+                    ),
+                    active = rule.enabled,
+                    heightDp = 34,
+                )
+                Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                    TextButton(onClick = { onEdit(rule) }, modifier = Modifier.weight(1f)) {
+                        ButtonLabel("Edit")
+                    }
+                    TextButton(onClick = { onTest(rule) }, modifier = Modifier.weight(1f)) {
+                        ButtonLabel("Test")
+                    }
+                    TextButton(onClick = { onDelete(rule) }, modifier = Modifier.weight(1f)) {
+                        ButtonLabel("Delete")
+                    }
                 }
             }
-            Switch(
-                checked = rule.enabled,
-                onCheckedChange = {
-                    haptics.performHapticFeedback(HapticFeedbackType.LongPress)
-                    onToggle(it)
-                },
-            )
-        }
-        LedStrip(
-            rule.pattern,
-            Ambient(
-                pattern = rule.pattern,
-                color = rule.color,
-                speedMs = rule.speedMs,
-                brightness = rule.brightness,
-            ),
-            active = rule.enabled,
-            heightDp = 34,
-        )
-        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-            FilledTonalButton(onClick = onEdit, modifier = Modifier.weight(1f)) { ButtonLabel("Edit") }
-            FilledTonalButton(onClick = onTest, modifier = Modifier.weight(1f)) { ButtonLabel("Test") }
-            TextButton(onClick = onDelete, modifier = Modifier.weight(1f)) { ButtonLabel("Delete") }
         }
     }
+}
+
+fun AppRule.conditionLabel(): String = when (trigger) {
+    Trigger.FOREGROUND -> "While open"
+    Trigger.NOTIFICATION -> keyword.trim().takeIf { it.isNotEmpty() }
+        ?.let { "Notification contains \u201c$it\u201d" }
+        ?: "Any notification"
 }
 
 @Composable
@@ -315,6 +346,7 @@ private fun RuleEditorDialog(
                     label = { if (it == Trigger.NOTIFICATION) "On notification" else "While open" },
                     onSelect = { r = r.copy(trigger = it) },
                 )
+                Caption("Notification rules may be multiple; only one while-open rule is allowed.")
 
                 PatternCarousel(
                     selected = r.pattern,
@@ -331,7 +363,16 @@ private fun RuleEditorDialog(
                     OutlinedTextField(
                         value = r.keyword,
                         onValueChange = { r = r.copy(keyword = it) },
-                        label = { Text("Only if it mentions (optional)") },
+                        label = { Text("Notification contains (optional)") },
+                        supportingText = {
+                            Caption(
+                                if (r.keyword.isBlank()) {
+                                    "Leave blank to match any notification from ${r.label}."
+                                } else {
+                                    "Matches ${r.label} notifications containing this text."
+                                }
+                            )
+                        },
                         singleLine = true,
                         shape = MaterialTheme.shapes.medium,
                         modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/hilight/studio/LiveScreen.kt
+++ b/app/src/main/java/com/hilight/studio/LiveScreen.kt
@@ -193,8 +193,7 @@ fun LiveScreen(store: Store) {
                     Text(r.label, style = MaterialTheme.typography.bodyLarge)
                     Text(
                         (if (r.randomColor) "random" else r.pattern.label) +
-                            " · " +
-                            if (r.trigger == Trigger.NOTIFICATION) "notify" else "in app",
+                            " · " + r.conditionLabel(),
                         style = MaterialTheme.typography.bodyMedium,
                         color = if (r.enabled) MaterialTheme.colorScheme.primary
                         else MaterialTheme.colorScheme.onSurfaceVariant,

--- a/app/src/main/java/com/hilight/studio/Model.kt
+++ b/app/src/main/java/com/hilight/studio/Model.kt
@@ -2,6 +2,7 @@ package com.hilight.studio
 
 import org.json.JSONArray
 import org.json.JSONObject
+import java.util.UUID
 
 /**
  * Patterns the renderer understands.
@@ -122,6 +123,8 @@ data class AppRule(
     val onlyWhenScreenOff: Boolean = false,
     /** only fire when the title or text contains this, case-insensitive; empty means anything */
     val keyword: String = "",
+    /** Stable identity used to update or remove one rule without relying on its package. */
+    val id: String = UUID.randomUUID().toString(),
 ) {
     /** The catch-all rule, which matches any app without one of its own. */
     val isCatchAll: Boolean get() = pkg == ANY_APP
@@ -139,6 +142,7 @@ data class AppRule(
         put("brightness", brightness.toDouble())
         put("onlyWhenScreenOff", onlyWhenScreenOff)
         put("keyword", keyword)
+        put("id", id)
     }
 
     companion object {
@@ -159,6 +163,7 @@ data class AppRule(
             brightness = o.optDouble("brightness", 1.0).toFloat(),
             onlyWhenScreenOff = o.optBoolean("onlyWhenScreenOff", false),
             keyword = o.optString("keyword", ""),
+            id = o.optString("id", "").trim().ifEmpty { UUID.randomUUID().toString() },
         )
     }
 }

--- a/app/src/main/java/com/hilight/studio/NotificationTrigger.kt
+++ b/app/src/main/java/com/hilight/studio/NotificationTrigger.kt
@@ -13,14 +13,13 @@ class NotificationTrigger : NotificationListenerService() {
     override fun onNotificationPosted(sbn: StatusBarNotification) {
         Log.d(TAG, "posted by ${sbn.packageName}")
         if (sbn.packageName == packageName && sbn.notification.channelId == "fg_watch") return
-        val rule = store.ruleFor(sbn.packageName, Trigger.NOTIFICATION) ?: return
+        val rule = store.notificationRuleFor(sbn.packageName, searchableText(sbn)) ?: return
         if (sbn.isOngoing) return                       // media/progress notifications repeat a lot
         if (rule.onlyWhenScreenOff && screenOn()) return
         if (store.respectDnd.value && inDoNotDisturb()) {
             Log.i(TAG, "suppressed by Do Not Disturb")
             return
         }
-        if (rule.keyword.isNotBlank() && !matchesKeyword(sbn, rule.keyword)) return
         Log.i(TAG, "alert for ${sbn.packageName} pattern=${rule.pattern.key}")
         store.fireAlert(rule)
     }
@@ -36,16 +35,15 @@ class NotificationTrigger : NotificationListenerService() {
                 it == INTERRUPTION_FILTER_NONE
         }
 
-    private fun matchesKeyword(sbn: StatusBarNotification, keyword: String): Boolean {
+    private fun searchableText(sbn: StatusBarNotification): String {
         val extras = sbn.notification.extras
-        val haystack = buildString {
+        return buildString {
             append(extras.getCharSequence(android.app.Notification.EXTRA_TITLE) ?: "")
             append(' ')
             append(extras.getCharSequence(android.app.Notification.EXTRA_TEXT) ?: "")
             append(' ')
             append(extras.getCharSequence(android.app.Notification.EXTRA_BIG_TEXT) ?: "")
         }
-        return haystack.contains(keyword.trim(), ignoreCase = true)
     }
 
     private fun screenOn(): Boolean =

--- a/app/src/main/java/com/hilight/studio/RuleMatcher.kt
+++ b/app/src/main/java/com/hilight/studio/RuleMatcher.kt
@@ -1,0 +1,18 @@
+package com.hilight.studio
+
+/** Selects the one notification rule that should handle a notification. */
+object RuleMatcher {
+    fun notificationRuleFor(
+        rules: List<AppRule>,
+        packageName: String,
+        searchableText: String,
+    ): AppRule? {
+        val enabled = rules.filter { it.enabled && it.trigger == Trigger.NOTIFICATION }
+        val exact = enabled.filter { it.pkg == packageName }
+        val candidates = if (exact.isNotEmpty()) exact else enabled.filter { it.isCatchAll }
+
+        return candidates.firstOrNull { rule ->
+            rule.keyword.isNotBlank() && searchableText.contains(rule.keyword.trim(), ignoreCase = true)
+        } ?: candidates.firstOrNull { it.keyword.isBlank() }
+    }
+}

--- a/app/src/main/java/com/hilight/studio/Store.kt
+++ b/app/src/main/java/com/hilight/studio/Store.kt
@@ -262,13 +262,26 @@ class Store private constructor(private val app: Context) {
     }
 
     fun upsertRule(rule: AppRule) {
-        _rules.value = _rules.value.filterNot { it.pkg == rule.pkg && it.trigger == rule.trigger } + rule
+        val current = _rules.value
+        val existingIndex = current.indexOfFirst { it.id == rule.id }
+        val withoutOtherForeground = if (rule.trigger == Trigger.FOREGROUND) {
+            current.filter { it.id == rule.id || it.pkg != rule.pkg || it.trigger != Trigger.FOREGROUND }
+        } else {
+            current
+        }
+        _rules.value = if (existingIndex >= 0) {
+            withoutOtherForeground.toMutableList().also {
+                it[it.indexOfFirst { saved -> saved.id == rule.id }] = rule
+            }
+        } else {
+            withoutOtherForeground + rule
+        }
         saveRules()
         ForegroundWatcher.syncRunning(app, _rules.value, _enabled.value)
     }
 
     fun removeRule(rule: AppRule) {
-        _rules.value = _rules.value.filterNot { it.pkg == rule.pkg && it.trigger == rule.trigger }
+        _rules.value = _rules.value.filterNot { it.id == rule.id }
         saveRules()
         ForegroundWatcher.syncRunning(app, _rules.value, _enabled.value)
     }
@@ -321,12 +334,15 @@ class Store private constructor(private val app: Context) {
             }.getOrNull()
         } ?: emptyList()
 
-    /** A rule for this package if there is one, otherwise the catch-all. */
+    /** A rule for this package if there is one, otherwise the catch-all. Foreground stays singular. */
     fun ruleFor(pkg: String, trigger: Trigger): AppRule? {
         val enabled = _rules.value.filter { it.enabled && it.trigger == trigger }
         return enabled.firstOrNull { it.pkg == pkg }
             ?: enabled.firstOrNull { it.isCatchAll }
     }
+
+    fun notificationRuleFor(pkg: String, searchableText: String): AppRule? =
+        RuleMatcher.notificationRuleFor(_rules.value, pkg, searchableText)
 
     // ------------------------------------------------------------------ light output
 

--- a/app/src/test/java/com/hilight/studio/RuleMatcherTest.kt
+++ b/app/src/test/java/com/hilight/studio/RuleMatcherTest.kt
@@ -1,0 +1,85 @@
+package com.hilight.studio
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class RuleMatcherTest {
+    private fun rule(pkg: String, keyword: String = "") =
+        AppRule(pkg = pkg, label = pkg, keyword = keyword)
+
+    @Test
+    fun `two same-app contacts match independently`() {
+        val first = rule("chat", "Alice")
+        val second = rule("chat", "Bob")
+        val rules = listOf(first, second)
+
+        assertEquals(first, RuleMatcher.notificationRuleFor(rules, "chat", "Alice: hello"))
+        assertEquals(second, RuleMatcher.notificationRuleFor(rules, "chat", "Bob: hello"))
+    }
+
+    @Test
+    fun `specific rule beats an earlier blank fallback`() {
+        val blank = rule("mail")
+        val specific = rule("mail", "invoice")
+
+        assertEquals(
+            specific,
+            RuleMatcher.notificationRuleFor(listOf(blank, specific), "mail", "New invoice"),
+        )
+    }
+
+    @Test
+    fun `app blank rule is the fallback when specific rule misses`() {
+        val blank = rule("mail")
+        val specific = rule("mail", "invoice")
+
+        assertEquals(
+            blank,
+            RuleMatcher.notificationRuleFor(listOf(specific, blank), "mail", "New message"),
+        )
+    }
+
+    @Test
+    fun `app rules return no match without a matching condition or fallback`() {
+        assertNull(
+            RuleMatcher.notificationRuleFor(listOf(rule("mail", "invoice")), "mail", "New message"),
+        )
+    }
+
+    @Test
+    fun `global catch-all handles an app without exact rules`() {
+        val global = rule(AppRule.ANY_APP)
+
+        assertEquals(global, RuleMatcher.notificationRuleFor(listOf(global), "chrome", "New mail"))
+    }
+
+    @Test
+    fun `enabled exact rules block global fallback even when they miss`() {
+        val exact = rule("mail", "invoice")
+        val global = rule(AppRule.ANY_APP)
+
+        assertNull(RuleMatcher.notificationRuleFor(listOf(exact, global), "mail", "New message"))
+    }
+
+    @Test
+    fun `disabled rules are ignored`() {
+        val disabled = rule("bethany", "Bethany").copy(enabled = false)
+
+        assertNull(RuleMatcher.notificationRuleFor(listOf(disabled), "bethany", "Bethany: hello"))
+    }
+
+    @Test
+    fun `keyword matching is case insensitive`() {
+        val matching = rule("mail", "INVOICE")
+
+        assertEquals(matching, RuleMatcher.notificationRuleFor(listOf(matching), "mail", "new invoice"))
+    }
+
+    @Test
+    fun `surrounding keyword whitespace is trimmed`() {
+        val matching = rule("mail", "  invoice  ")
+
+        assertEquals(matching, RuleMatcher.notificationRuleFor(listOf(matching), "mail", "new invoice"))
+    }
+}


### PR DESCRIPTION
This will allow multiple rules per single app, so that you can set up custom light behavior for different notifications from same app. For example, in Signal or WhatsApp, you can set up green lights for receiving a message from Person 1 and red lights for Person 2.

## Summary
- Stable per-rule IDs with backward-compatible flat persistence.
- Deterministic specific-before-fallback matching while preserving exact-app/global semantics and one foreground rule.
- Grouped app UI with independent controls and per-rule LED previews.
- Live summary clarity and matcher tests.

## Testing
- `./gradlew :app:testDebugUnitTest`
- `./gradlew :app:assembleDebug`
- Manually verified multiple rules for one app on Pixel 11 Pro XL.