### PR TITLE
Shrink release APK with R8

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -47,7 +47,14 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
+            // material-icons-extended contains every Compose icon. R8 removes the thousands this
+            // app does not use, while resource shrinking drops their now-unreferenced resources.
+            isMinifyEnabled = true
+            isShrinkResources = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro",
+            )
             // Public APKs use the permanent release certificate when signing material is present
             // and remain non-debuggable. The stable certificate enables future in-place updates;
             // Play Protect reputation checks are separate and are not guaranteed by signing alone.

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,10 @@
+# The ADB renderer is launched by class name through app_process, not by Android or app code.
+-keep public class com.hilight.core.AdbHelper {
+    public static void main(java.lang.String[]);
+}
+
+# Shizuku constructs the user service outside this app's process.
+-keep public class com.hilight.studio.HiLightUserService {
+    public <init>();
+    public *;
+}


### PR DESCRIPTION
## Summary

Enable R8 optimization and unused-resource shrinking for release builds to address #11.

The current APK includes the full `material-icons-extended` library. This change:

- enables release minification and resource shrinking with Android's optimized default ProGuard configuration
- allows R8 to remove unused icon and dependency bytecode
- preserves `AdbHelper.main()`, which is launched by class name through `app_process`
- preserves `HiLightUserService`, which Shizuku constructs outside the app process

No renderer, transport, or timing behavior is changed.

## Measured impact

I built base commit `e693f71` and this branch at `ab49bbc` as signed release APKs with the same API 37 toolchain and the same local verification key.

| Build | APK size |
| --- | ---: |
| Base release | 47,211,191 bytes (45.0 MiB) |
| R8 + resource shrinking | 4,202,138 bytes (4.0 MiB) |

That is a **91.1% reduction**.

## Verification

<img width="1280" height="2856" alt="Screenshot_20260821-202554" src="https://github.com/user-attachments/assets/8abdff67-aa9b-4e65-be38-bd710efe929a" />
<img width="1280" height="2856" alt="Screenshot_20260821-202833" src="https://github.com/user-attachments/assets/8a571b44-03d5-464b-9847-8328824aad0b" />


- [x] Built both base and optimized release APKs with `:app:assembleRelease`
- [x] Both APKs pass `apksigner verify` using APK Signature Scheme v2
- [x] `:app:testDebugUnitTest` passes
- [x] Full `:app:lint` passes
- [x] Confirmed `AdbHelper` and `HiLightUserService` remain in the compact DEX
- [x] Started the compact APK's ADB helper on-device; it ran as shell UID `2000`, connected all 8 LEDs, and reported `session=true`
- [x] Installed the 4.0 MiB APK on a Pixel 11 Pro running Android 17 / API 37
- [x] Cold-launched `com.hilight.studio/.MainActivity` with Android reporting `Status: ok` (226 ms)
- [x] Confirmed the app process remained alive with no fatal runtime exceptions in its process log
- [x] No notification contents or other personal data are included

The device smoke test used a throwaway local verification certificate; this PR does not change the project's release-signing configuration.

Closes [#11](https://github.com/DhananjayBhosale/hilight-studio/issues/11)