### PR TITLE
Use bounded hardware light effects safely

### DIFF
--- a/app/src/test/java/com/hilight/core/EngineEffectPolicyTest.java
+++ b/app/src/test/java/com/hilight/core/EngineEffectPolicyTest.java
@@ -1,0 +1,177 @@
+package com.hilight.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public final class EngineEffectPolicyTest {
+
+    @Test
+    public void iterationCountCeilsToCoverTheFiniteDeadline() {
+        assertEquals(17, Engine.effectIterations(10_317, 628));
+        assertEquals(4, Engine.effectIterations(4_000, 1_200));
+        assertEquals(1, Engine.effectIterations(628, 628));
+        assertEquals(1, Engine.effectIterations(627, 628));
+        assertTrue(Engine.coverageEnd(0, Engine.effectIterations(10_317, 628), 628) >= 10_317);
+        assertTrue(Engine.coverageEnd(0, 16, 628) < 10_317);
+    }
+
+    @Test
+    public void ambientTimeoutIsBoundedAtStateIngress() {
+        assertEquals(1_000, Engine.clampAmbientTimeout(999));
+        assertEquals(Engine.DEFAULT_AMBIENT_TIMEOUT_MS,
+                Engine.clampAmbientTimeout(Engine.DEFAULT_AMBIENT_TIMEOUT_MS));
+        assertEquals(123_456, Engine.clampAmbientTimeout(123_456));
+        assertEquals(Engine.MAX_AMBIENT_TIMEOUT_MS,
+                Engine.clampAmbientTimeout(Engine.MAX_AMBIENT_TIMEOUT_MS + 1));
+        assertEquals(Engine.MAX_AMBIENT_TIMEOUT_MS,
+                Engine.clampAmbientTimeout(Long.MAX_VALUE));
+    }
+
+    @Test
+    public void maximumAmbientTimeoutCoversDeadlineWithoutIterationSaturation() {
+        int iterations = Engine.effectIterations(Engine.MAX_AMBIENT_TIMEOUT_MS, Engine.FRAME_MS);
+        assertEquals(4_546, iterations);
+        assertTrue(iterations < Integer.MAX_VALUE);
+        assertTrue(Engine.coverageEnd(0, iterations, Engine.FRAME_MS)
+                >= Engine.MAX_AMBIENT_TIMEOUT_MS);
+    }
+
+    @Test
+    public void iterationCountRejectsInvalidInputsAndSaturates() {
+        assertEquals(0, Engine.effectIterations(0, 628));
+        assertEquals(0, Engine.effectIterations(-1, 628));
+        assertEquals(0, Engine.effectIterations(628, 0));
+        assertEquals(0, Engine.effectIterations(628, -1));
+        assertEquals(Integer.MAX_VALUE, Engine.effectIterations(Long.MAX_VALUE, 1));
+    }
+
+    @Test
+    public void cachedSubmissionUsesTheExactGateDeadline() {
+        long now = 1_000;
+        long required = Engine.requiredCoverageEnd(now, 628);
+        assertTrue(Engine.isHardwareSubmissionLive(
+                true, true, true, true, true, required, required));
+        assertTrue(Engine.isHardwareSubmissionLive(
+                true, true, true, true, true, required + 1, required));
+        assertFalse(Engine.isHardwareSubmissionLive(
+                true, true, true, true, true, required - 1, required));
+        assertFalse(Engine.isHardwareSubmissionLive(
+                true, true, true, true, false, required, required));
+        assertFalse(Engine.isHardwareSubmissionLive(
+                false, true, true, true, true, required, required));
+        assertEquals(Long.MAX_VALUE,
+                Engine.requiredCoverageEnd(Long.MAX_VALUE - 1, Long.MAX_VALUE));
+    }
+
+    @Test
+    public void terminationTimingMatchesValidatedBlackDrain() {
+        assertEquals(132, Engine.BLACK_EFFECT_WAIT_MS);
+        assertEquals(66, Engine.BLACK_STATIC_DRAIN_MS);
+        assertEquals(2 * Engine.FRAME_MS, Engine.BLACK_EFFECT_WAIT_MS);
+        assertEquals(Engine.FRAME_MS, Engine.BLACK_STATIC_DRAIN_MS);
+    }
+
+    @Test
+    public void taperBucketReplacementRequiresACompleteReplacementCycle() {
+        long now = 1_000;
+        long period = 628;
+        for (long remaining : new long[]{0, 305, 627}) {
+            long required = Engine.requiredCoverageEnd(now, remaining);
+            assertTrue(Engine.shouldReuseHardwareSubmission(
+                    true, false, true, true, true, required, required, remaining, period));
+        }
+        for (long remaining : new long[]{628, 629}) {
+            long required = Engine.requiredCoverageEnd(now, remaining);
+            assertFalse(Engine.shouldReuseHardwareSubmission(
+                    true, false, true, true, true, required, required, remaining, period));
+        }
+
+        long required1199 = Engine.requiredCoverageEnd(now, 1_199);
+        assertTrue(Engine.shouldReuseHardwareSubmission(
+                true, false, true, true, true, required1199, required1199, 1_199, 1_200));
+        long required1200 = Engine.requiredCoverageEnd(now, 1_200);
+        assertFalse(Engine.shouldReuseHardwareSubmission(
+                true, false, true, true, true, required1200, required1200, 1_200, 1_200));
+    }
+
+    @Test
+    public void matchingBucketReusesNormallyWhenCoverageIsSufficient() {
+        assertTrue(Engine.shouldReuseHardwareSubmission(
+                true, true, true, true, true, Long.MAX_VALUE, Long.MAX_VALUE,
+                Long.MAX_VALUE, 0));
+        assertTrue(Engine.shouldReuseHardwareSubmission(
+                true, true, true, true, true, 1_000, 1_000, -1, -1));
+    }
+
+    @Test
+    public void bucketReuseRequiresEveryOtherCacheIdentityAndCoverage() {
+        long now = 1_000;
+        long required = Engine.requiredCoverageEnd(now, 305);
+        assertFalse(Engine.shouldReuseHardwareSubmission(
+                false, false, true, true, true, required, required, 305, 628));
+        assertFalse(Engine.shouldReuseHardwareSubmission(
+                true, false, false, true, true, required, required, 305, 628));
+        assertFalse(Engine.shouldReuseHardwareSubmission(
+                true, false, true, false, true, required, required, 305, 628));
+        assertFalse(Engine.shouldReuseHardwareSubmission(
+                true, false, true, true, false, required, required, 305, 628));
+        assertFalse(Engine.shouldReuseHardwareSubmission(
+                true, false, true, true, true, required - 1, required, 305, 628));
+    }
+
+    @Test
+    public void nonpositivePeriodDoesNotGuardBucketMismatch() {
+        long now = 1_000;
+        long required = Engine.requiredCoverageEnd(now, 0);
+        assertFalse(Engine.shouldReuseHardwareSubmission(
+                true, false, true, true, true, required, required, 0, 0));
+        assertFalse(Engine.shouldReuseHardwareSubmission(
+                true, false, true, true, true, required, required, 0, -1));
+    }
+
+    @Test
+    public void coverageArithmeticSaturatesInsteadOfWrapping() {
+        assertEquals(Long.MAX_VALUE,
+                Engine.coverageEnd(Long.MAX_VALUE - 1, Integer.MAX_VALUE, Long.MAX_VALUE));
+    }
+
+    @Test
+    public void candidateSeedMixIsDeterministicButChangesPerCandidateCounter() {
+        long first = Engine.mixSeed(1L, 2L, 3);
+        assertEquals(first, Engine.mixSeed(1L, 2L, 3));
+        assertNotEquals(first, Engine.mixSeed(2L, 2L, 3));
+        assertNotEquals(first, Engine.mixSeed(1L, 3L, 3));
+        assertNotEquals(first, Engine.mixSeed(1L, 2L, 4));
+    }
+
+    @Test
+    public void safetyScaleBucketsOnlyDownwardInFivePercentSteps() {
+        assertEquals(1.0, Engine.scaleBucket(1.0), 0.0);
+        assertEquals(0.95, Engine.scaleBucket(0.99), 0.0);
+        assertEquals(0.95, Engine.scaleBucket(0.95), 0.0);
+        assertEquals(0.90, Engine.scaleBucket(0.949), 0.0);
+        assertEquals(0.05, Engine.scaleBucket(0.051), 0.0);
+        assertEquals(0.05, Engine.scaleBucket(0.05), 0.0);
+        assertEquals(0.0, Engine.scaleBucket(0.02), 0.0);
+    }
+
+    @Test
+    public void interruptedDrainWaitsAndRestoresInterruptStatus() {
+        Thread.interrupted();
+        long started = System.nanoTime();
+        try {
+            Thread.currentThread().interrupt();
+            assertTrue(Engine.sleepPreservingInterrupt(20));
+            long elapsed = System.nanoTime() - started;
+            assertTrue("drain returned before its bounded wait", elapsed >= 10_000_000L);
+            assertTrue("drain exceeded its bounded wait", elapsed < 1_000_000_000L);
+            assertTrue(Thread.currentThread().isInterrupted());
+        } finally {
+            Thread.interrupted();
+        }
+    }
+}

--- a/app/src/test/java/com/hilight/core/LightsBackendEffectSafetyTest.java
+++ b/app/src/test/java/com/hilight/core/LightsBackendEffectSafetyTest.java
@@ -1,0 +1,280 @@
+package com.hilight.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.json.JSONObject;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class LightsBackendEffectSafetyTest {
+
+    @Test
+    public void certifiedProfileRequiresExactFingerprintTopologyAndCapabilities() {
+        int[] ids = {8, 1, 7, 2, 6, 3, 5, 4};
+        boolean[] rgb = allTrue();
+        boolean[] animation = allTrue();
+        long[] periods = allPeriods(66);
+
+        assertTrue(LightsBackend.isCertifiedProfile(
+                LightsBackend.CERTIFIED_FINGERPRINT, ids, rgb, animation, periods));
+        assertFalse(LightsBackend.isCertifiedProfile(
+                "google/kodiak/kodiak:17/other:user/release-keys",
+                ids, rgb, animation, periods));
+
+        int[] wrongId = ids.clone();
+        wrongId[0] = 9;
+        assertFalse(LightsBackend.isCertifiedProfile(
+                LightsBackend.CERTIFIED_FINGERPRINT, wrongId, rgb, animation, periods));
+        boolean[] noRgb = rgb.clone();
+        noRgb[3] = false;
+        assertFalse(LightsBackend.isCertifiedProfile(
+                LightsBackend.CERTIFIED_FINGERPRINT, ids, noRgb, animation, periods));
+        boolean[] noAnimation = animation.clone();
+        noAnimation[4] = false;
+        assertFalse(LightsBackend.isCertifiedProfile(
+                LightsBackend.CERTIFIED_FINGERPRINT, ids, rgb, noAnimation, periods));
+        long[] noPeriod = periods.clone();
+        noPeriod[5] = 0;
+        assertFalse(LightsBackend.isCertifiedProfile(
+                LightsBackend.CERTIFIED_FINGERPRINT, ids, rgb, animation, noPeriod));
+    }
+
+    @Test
+    public void capabilityGetterFailuresKeepTopologyButDisableEffects() {
+        for (int failure = 0; failure < 3; failure++) {
+            List<LightsBackend.CapabilitySource> sources = new ArrayList<>();
+            for (int i = 0; i < 8; i++) {
+                sources.add(source(8 - i, failure == 0 && i == 2,
+                        failure == 1 && i == 2, failure == 2 && i == 2));
+            }
+            LightsBackend.CapabilityRead read = LightsBackend.readCapabilities(sources);
+            assertEquals(Arrays.toString(new int[]{8, 7, 6, 5, 4, 3, 2, 1}),
+                    Arrays.toString(read.ids));
+            assertEquals(8, read.ids.length);
+            assertFalse(read.capabilitiesKnown);
+            assertEquals(0, read.quantumMs);
+            assertFalse(LightsBackend.isCertifiedProfile(
+                    LightsBackend.CERTIFIED_FINGERPRINT, read.ids, read.rgbControl,
+                    read.animationControl, read.minUpdatePeriods));
+        }
+    }
+
+    @Test
+    public void validatorAcceptsThePreemptiveBlackTerminatorAtCertifiedQuantum() {
+        SequenceCompiler.Plan terminator = SequenceCompiler.blackTerminator(8, 66);
+        assertTrue(LightsBackend.isEffectPlanSafe(terminator, 33, 1));
+        assertTrue(LightsBackend.isEffectPlanSafe(66,
+                SequenceCompiler.Interpolation.LINEAR, delays(8, 66, 2),
+                blackColors(8, 2), 33, 1));
+
+        long[][] badTiming = delays(8, 66, 2);
+        badTiming[0][1] = 32;
+        assertFalse(LightsBackend.isEffectPlanSafe(66,
+                SequenceCompiler.Interpolation.LINEAR, badTiming,
+                blackColors(8, 2), 33, 1));
+    }
+
+    @Test
+    public void validatorAcceptsBoundedEightByNinePlans() throws Exception {
+        SequenceCompiler.Plan compilerPlan = SequenceCompiler.compile(
+                config("mode", "wave", "speedMs", 320), 0, 8, 40, 1.0, 123L);
+        assertTrue(LightsBackend.isEffectPlanSafe(compilerPlan, 40, 1));
+
+        long[][] delays = delays(8, 40);
+        int[][] colors = colors(8, 9);
+
+        assertTrue(LightsBackend.isEffectPlanSafe(320,
+                SequenceCompiler.Interpolation.LINEAR, delays, colors, 40, 1));
+        assertTrue(LightsBackend.isEffectPlanSafe(320,
+                SequenceCompiler.Interpolation.NONE, delays, colors, 40, Integer.MAX_VALUE));
+    }
+
+    @Test
+    public void validatorRejectsTrackCountAndEveryMalformedTrackShape() {
+        long[][] delays = delays(8, 40);
+        int[][] colors = colors(8, 9);
+
+        assertFalse(LightsBackend.isEffectPlanSafe(320,
+                SequenceCompiler.Interpolation.LINEAR, trim(delays, 7), trim(colors, 7), 40, 1));
+
+        long[][] badFirstDelay = copy(delays);
+        badFirstDelay[0][0] = 1;
+        assertFalse(LightsBackend.isEffectPlanSafe(320,
+                SequenceCompiler.Interpolation.LINEAR, badFirstDelay, colors, 40, 1));
+
+        long[][] badLaterDelay = copy(delays);
+        badLaterDelay[0][1] = 39;
+        assertFalse(LightsBackend.isEffectPlanSafe(320,
+                SequenceCompiler.Interpolation.LINEAR, badLaterDelay, colors, 40, 1));
+
+        long[][] badDuration = copy(delays);
+        badDuration[0][8] = 41;
+        assertFalse(LightsBackend.isEffectPlanSafe(320,
+                SequenceCompiler.Interpolation.LINEAR, badDuration, colors, 40, 1));
+
+        int[][] badClosure = copy(colors);
+        badClosure[0][8] = 0xFF000000;
+        assertFalse(LightsBackend.isEffectPlanSafe(320,
+                SequenceCompiler.Interpolation.LINEAR, delays, badClosure, 40, 1));
+
+        long[][] tenPoints = new long[8][];
+        int[][] tenColors = new int[8][];
+        for (int i = 0; i < 8; i++) {
+            tenPoints[i] = new long[10];
+            tenColors[i] = new int[10];
+            for (int j = 1; j < 10; j++) tenPoints[i][j] = 40;
+            tenColors[i][0] = tenColors[i][9] = 0xFFFF0000;
+        }
+        assertFalse(LightsBackend.isEffectPlanSafe(360,
+                SequenceCompiler.Interpolation.LINEAR, tenPoints, tenColors, 40, 1));
+
+        assertFalse(LightsBackend.isEffectPlanSafe(320,
+                null, delays, colors, 40, 1));
+        assertFalse(LightsBackend.isEffectPlanSafe(320,
+                SequenceCompiler.Interpolation.LINEAR, delays, colors, 40, 0));
+    }
+
+    private static LightsBackend.CapabilitySource source(final int id,
+                                                            final boolean throwRgb,
+                                                            final boolean throwAnimation,
+                                                            final boolean throwPeriod) {
+        return new LightsBackend.CapabilitySource() {
+            @Override public int id() { return id; }
+
+            @Override public boolean hasRgbControl() {
+                if (throwRgb) throw new AssertionError("rgb");
+                return true;
+            }
+
+            @Override public boolean hasAnimationControl() {
+                if (throwAnimation) throw new AssertionError("animation");
+                return true;
+            }
+
+            @Override public long getMinUpdatePeriodMillis() {
+                if (throwPeriod) throw new AssertionError("period");
+                return 66;
+            }
+        };
+    }
+
+    private static boolean[] allTrue() {
+        boolean[] values = new boolean[8];
+        for (int i = 0; i < values.length; i++) values[i] = true;
+        return values;
+    }
+
+    private static long[] allPeriods(long period) {
+        long[] values = new long[8];
+        for (int i = 0; i < values.length; i++) values[i] = period;
+        return values;
+    }
+
+    private static long[][] delays(int lights, long quantum) {
+        return delays(lights, quantum, 9);
+    }
+
+    private static long[][] delays(int lights, long quantum, int points) {
+        long[][] values = new long[lights][points];
+        for (int light = 0; light < lights; light++) {
+            for (int point = 1; point < points; point++) values[light][point] = quantum;
+        }
+        return values;
+    }
+
+    private static int[][] colors(int lights, int points) {
+        int[][] values = new int[lights][points];
+        for (int light = 0; light < lights; light++) {
+            values[light][0] = 0xFFFF0000;
+            values[light][points - 1] = 0xFFFF0000;
+        }
+        return values;
+    }
+
+    private static long[][] copy(long[][] source) {
+        long[][] result = new long[source.length][];
+        for (int i = 0; i < source.length; i++) result[i] = source[i].clone();
+        return result;
+    }
+
+    private static int[][] blackColors(int lights, int points) {
+        int[][] values = new int[lights][points];
+        for (int light = 0; light < lights; light++) {
+            for (int point = 0; point < points; point++) values[light][point] = 0xFF000000;
+        }
+        return values;
+    }
+
+    private static int[][] copy(int[][] source) {
+        int[][] result = new int[source.length][];
+        for (int i = 0; i < source.length; i++) result[i] = source[i].clone();
+        return result;
+    }
+
+    private static long[][] trim(long[][] source, int length) {
+        long[][] result = new long[length][];
+        System.arraycopy(source, 0, result, 0, length);
+        return result;
+    }
+
+    private static int[][] trim(int[][] source, int length) {
+        int[][] result = new int[length][];
+        System.arraycopy(source, 0, result, 0, length);
+        return result;
+    }
+
+    private static JSONObject config(Object... entries) throws Exception {
+        Field field = Class.forName("sun.misc.Unsafe").getDeclaredField("theUnsafe");
+        field.setAccessible(true);
+        Object unsafe = field.get(null);
+        TestConfig cfg = (TestConfig) unsafe.getClass()
+                .getMethod("allocateInstance", Class.class).invoke(unsafe, TestConfig.class);
+        cfg.values = new HashMap<>();
+        for (int i = 0; i < entries.length; i += 2) {
+            cfg.values.put((String) entries[i], entries[i + 1]);
+        }
+        return cfg;
+    }
+
+    private static final class TestConfig extends JSONObject {
+        private Map<String, Object> values;
+
+        @Override
+        public String optString(String name, String fallback) {
+            Object value = values.get(name);
+            return value == null ? fallback : String.valueOf(value);
+        }
+
+        @Override
+        public long optLong(String name, long fallback) {
+            Object value = values.get(name);
+            return value instanceof Number ? ((Number) value).longValue() : fallback;
+        }
+
+        @Override
+        public double optDouble(String name, double fallback) {
+            Object value = values.get(name);
+            return value instanceof Number ? ((Number) value).doubleValue() : fallback;
+        }
+
+        @Override
+        public boolean optBoolean(String name, boolean fallback) {
+            Object value = values.get(name);
+            return value instanceof Boolean ? (Boolean) value : fallback;
+        }
+
+        @Override
+        public org.json.JSONArray optJSONArray(String name) {
+            return null;
+        }
+    }
+}
+

--- a/app/src/test/java/com/hilight/core/OutputGateTest.java
+++ b/app/src/test/java/com/hilight/core/OutputGateTest.java
@@ -17,8 +17,9 @@ public final class OutputGateTest {
 
         assertEquals(OutputGate.Layer.AMBIENT, gate.next(1_000));
         assertEquals(OutputGate.Layer.BLANK, gate.next(TIMEOUT + 1));
-        // the blank latch stops a binder push every frame once the array is already dark
-        assertEquals(OutputGate.Layer.IDLE, gate.next(TIMEOUT + 100));
+        // Engine must force black on BLANK, retain its session for this full drain interval,
+        // then release only when this following render tick observes IDLE.
+        assertEquals(OutputGate.Layer.IDLE, gate.next(TIMEOUT + 1 + Engine.FRAME_MS));
         assertTrue(gate.isAmbientHeld());
     }
 
@@ -35,9 +36,9 @@ public final class OutputGateTest {
         assertEquals(OutputGate.Layer.ALERT, gate.next(fired));
         assertEquals(OutputGate.Layer.ALERT, gate.next(fired + 9_999));
 
-        // and must hand the array back the moment it expires, not sit on the last lit frame
+        // and must hand the array back on the following render tick, not sit on the last lit frame
         assertEquals(OutputGate.Layer.BLANK, gate.next(fired + 10_000));
-        assertEquals(OutputGate.Layer.IDLE, gate.next(fired + 10_033));
+        assertEquals(OutputGate.Layer.IDLE, gate.next(fired + 10_000 + Engine.FRAME_MS));
     }
 
     @Test
@@ -54,7 +55,7 @@ public final class OutputGateTest {
         gate.clearAlert();
         assertFalse(gate.isAlertHeld());
         assertEquals(OutputGate.Layer.BLANK, gate.next(fired + 2_000));
-        assertEquals(OutputGate.Layer.IDLE, gate.next(fired + 2_033));
+        assertEquals(OutputGate.Layer.IDLE, gate.next(fired + 2_000 + Engine.FRAME_MS));
     }
 
     @Test
@@ -88,6 +89,17 @@ public final class OutputGateTest {
         gate.armAmbient(TIMEOUT + 100, TIMEOUT);
         assertFalse(gate.isAmbientHeld());
         assertEquals(OutputGate.Layer.AMBIENT, gate.next(TIMEOUT + 200));
+    }
+
+    @Test
+    public void alertRemainingReachesZeroAtExpiry() {
+        OutputGate gate = new OutputGate();
+        gate.startAlert(5_000, 10_000);
+
+        assertEquals(10_000, gate.alertRemainingMs(5_000));
+        assertEquals(2_500, gate.alertRemainingMs(12_500));
+        assertEquals(0, gate.alertRemainingMs(15_000));
+        assertEquals(0, gate.alertRemainingMs(16_000));
     }
 
     @Test

--- a/app/src/test/java/com/hilight/core/SafetyGuardTest.java
+++ b/app/src/test/java/com/hilight/core/SafetyGuardTest.java
@@ -1,6 +1,7 @@
 package com.hilight.core;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -9,6 +10,67 @@ import org.junit.Test;
 public final class SafetyGuardTest {
 
     private static final int[] RED = {0xFFFF0000};
+
+    @Test
+    public void defaultFrameCadenceMatchesTheRenderLoop() {
+        assertEquals(66, SafetyGuard.FRAME_MS);
+        assertEquals(SafetyGuard.FRAME_MS, Engine.FRAME_MS);
+    }
+
+    @Test
+    public void observeCombinesDimWithPreTaperRampAndFloor() {
+        SafetyGuard guard = new SafetyGuard(10, 1_000, 0.5, 20, 20, 0.5);
+
+        assertEquals(0.8, guard.observe(true, 0, 0.8).scale, 0.000001);
+        assertEquals(0.8, guard.observe(true, 10, 0.8).scale, 0.000001);
+        assertEquals(0.6, guard.observe(true, 20, 0.8).scale, 0.000001);
+        assertEquals(0.4, guard.observe(true, 30, 0.8).scale, 0.000001);
+    }
+
+    @Test
+    public void observePreservesTheExistingNoDimThreshold() {
+        SafetyGuard guard = new SafetyGuard(10, 1_000, 0.5, 1_000, 20, 0.5);
+
+        // Software apply deliberately does not dim at .999 or above; hardware buckets must match.
+        assertEquals(1.0, guard.observe(true, 0, 0.999).scale, 0.000001);
+    }
+
+    @Test
+    public void observeChargesLitIntervalsConservativelyAndThenRests() {
+        SafetyGuard guard = new SafetyGuard(10, 100, 0.5, 1_000, 20, 0.5);
+
+        for (int now = 0; now <= 40; now += 10) {
+            assertFalse(guard.observe(true, now, 1.0).resting);
+        }
+        SafetyGuard.Decision decision = guard.observe(true, 50, 1.0);
+        assertTrue(decision.resting);
+        assertEquals(0.0, decision.scale, 0.000001);
+    }
+
+    @Test
+    public void observeUnlitResetsTaperWithoutChargingDuty() {
+        SafetyGuard guard = new SafetyGuard(10, 100, 0.5, 20, 20, 0.5);
+
+        guard.observe(true, 0, 1.0);
+        guard.observe(true, 10, 1.0);
+        assertEquals(1.0, guard.observe(false, 20, 0.8).scale, 0.000001);
+        guard.observe(true, 30, 1.0);
+        guard.observe(true, 40, 1.0);
+        guard.observe(true, 50, 1.0);
+        assertFalse(guard.isResting());
+        assertTrue(guard.observe(true, 60, 1.0).resting);
+    }
+
+    @Test
+    public void applyingAnObservedDecisionDoesNotChargeTwice() {
+        SafetyGuard observedGuard = new SafetyGuard(10, 1_000, 0.5, 20, 20, 0.5);
+        SafetyGuard directGuard = new SafetyGuard(10, 1_000, 0.5, 20, 20, 0.5);
+
+        SafetyGuard.Decision decision = observedGuard.observe(true, 0, 0.8);
+        assertArrayEquals(directGuard.apply(RED, 0, 0.8), observedGuard.apply(RED, decision));
+        assertEquals(2, observedGuard.dutyPercent());
+        assertEquals(2, directGuard.dutyPercent());
+    }
 
     @Test
     public void dutyLimitRestsThenResumesWhenTheWindowRollsOver() {

--- a/app/src/test/java/com/hilight/core/SequenceCompilerTest.java
+++ b/app/src/test/java/com/hilight/core/SequenceCompilerTest.java
@@ -1,0 +1,293 @@
+package com.hilight.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.json.JSONObject;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+public final class SequenceCompilerTest {
+
+    @Test
+    public void continuousModesUseNinePointLinearCanonicalPlans() throws Exception {
+        String[] modes = {"breathe", "pulse", "wave", "rainbow", "comet"};
+        for (String mode : modes) {
+            SequenceCompiler.Plan plan = SequenceCompiler.compile(
+                    config("mode", mode, "speedMs", 800, "color", 0xFFB040E0L),
+                    7, 8, 40, 0.5);
+            assertPlan(plan, 8, 40);
+            assertEquals(SequenceCompiler.Interpolation.LINEAR, plan.interpolation);
+            assertEquals(9, plan.tracks.get(0).points.size());
+        }
+    }
+
+    @Test
+    public void continuousSamplingUsesExternalScaleAndExactPeriod() throws Exception {
+        JSONObject cfg = config("mode", "breathe", "speedMs", 628, "color", 0xFFFF0000L);
+        SequenceCompiler.Plan plan = SequenceCompiler.compile(cfg, 0, 1, 33, 0.5);
+
+        assertPlan(plan, 1, 33);
+        assertEquals(628, plan.periodMs);
+        assertEquals(Renderer.scale(new Renderer().frame(cfg, 0, 1)[0], 0.5),
+                plan.tracks.get(0).colors.get(0).intValue());
+        assertEquals(9, plan.tracks.get(0).points.size());
+    }
+
+    @Test
+    public void blinkChaseAndRotatingCustomUseNoneAndRetainTiming() throws Exception {
+        SequenceCompiler.Plan blink = SequenceCompiler.compile(
+                config("mode", "blink", "speedMs", 601, "color", 0xFFFF0000L),
+                0, 8, 100, 1.0);
+        assertPlan(blink, 8, 100);
+        assertEquals(SequenceCompiler.Interpolation.NONE, blink.interpolation);
+        assertEquals(0, blink.tracks.get(0).delaysMs.get(0).longValue());
+        assertEquals(300, blink.tracks.get(0).delaysMs.get(1).longValue());
+        assertEquals(301, blink.tracks.get(0).delaysMs.get(2).longValue());
+        assertTrue(blink.tracks.get(0).colors.contains(0xFFFF0000));
+        assertTrue(blink.tracks.get(0).colors.contains(0xFF000000));
+
+        SequenceCompiler.Plan chase = SequenceCompiler.compile(
+                config("mode", "chase", "speedMs", 800, "color", 0xFF00FF00L),
+                0, 8, 100, 1.0);
+        assertPlan(chase, 8, 100);
+        assertEquals(SequenceCompiler.Interpolation.NONE, chase.interpolation);
+        assertEquals(9, chase.tracks.get(0).points.size());
+        assertEquals(100, chase.tracks.get(0).delaysMs.get(1).longValue());
+        assertTrue(chase.tracks.get(0).colors.contains(0xFF00FF00));
+        assertTrue(chase.tracks.get(0).colors.contains(0xFF000000));
+
+        SequenceCompiler.Plan custom = SequenceCompiler.compile(
+                config("mode", "custom", "rotateMs", 100, "color", 0xFFFF0000L),
+                0, 8, 25, 1.0);
+        assertPlan(custom, 8, 25);
+        assertEquals(SequenceCompiler.Interpolation.NONE, custom.interpolation);
+        assertEquals(100, custom.tracks.get(0).delaysMs.get(1).longValue());
+    }
+
+    @Test
+    public void seededRandomSupportsSmoothSteppedAndPerLedPlans() throws Exception {
+        JSONObject smoothCfg = config("mode", "random", "randomIntervalMs", 200,
+                "randomSmooth", true, "randomPerLed", false, "randomSaturation", 0.8);
+        SequenceCompiler.Plan smooth = SequenceCompiler.compile(smoothCfg, 0, 8, 25, 1.0, 1234L);
+        SequenceCompiler.Plan same = SequenceCompiler.compile(smoothCfg, 0, 8, 25, 1.0, 1234L);
+        SequenceCompiler.Plan changed = SequenceCompiler.compile(smoothCfg, 0, 8, 25, 1.0, 1235L);
+        assertPlan(smooth, 8, 25);
+        assertEquals(SequenceCompiler.Interpolation.LINEAR, smooth.interpolation);
+        assertPlansHaveSameColors(smooth, same);
+        assertPlansHaveDifferentColors(smooth, changed);
+        for (int stage = 0; stage < 8; stage++) {
+            assertEquals(smooth.tracks.get(0).colors.get(stage),
+                    smooth.tracks.get(1).colors.get(stage));
+        }
+
+        JSONObject steppedCfg = config("mode", "random", "randomIntervalMs", 200,
+                "randomSmooth", false, "randomPerLed", true);
+        SequenceCompiler.Plan stepped = SequenceCompiler.compile(steppedCfg, 0, 8, 25, 1.0, 99L);
+        assertPlan(stepped, 8, 25);
+        assertEquals(SequenceCompiler.Interpolation.NONE, stepped.interpolation);
+        boolean perLedDiffers = false;
+        for (int stage = 0; stage < 8; stage++) {
+            perLedDiffers |= !stepped.tracks.get(0).colors.get(stage)
+                    .equals(stepped.tracks.get(1).colors.get(stage));
+        }
+        assertTrue(perLedDiffers);
+    }
+
+    @Test
+    public void randomPhaseContinuesSmoothAndSteppedCyclesWithinNinePoints() throws Exception {
+        long interval = 200;
+        long seed = 1234L;
+        JSONObject smoothCfg = config("mode", "random", "randomIntervalMs", interval,
+                "randomSmooth", true, "randomPerLed", false, "randomSaturation", 0.8);
+        SequenceCompiler.Plan smoothAtStart = SequenceCompiler.compile(
+                smoothCfg, 0, 8, 25, 1.0, seed);
+        SequenceCompiler.Plan smoothAtBoundary = SequenceCompiler.compile(
+                smoothCfg, interval, 8, 25, 1.0, seed);
+        SequenceCompiler.Plan smoothAtHalf = SequenceCompiler.compile(
+                smoothCfg, interval + interval / 2, 8, 25, 1.0, seed);
+        assertPlan(smoothAtStart, 8, interval);
+        assertPlan(smoothAtBoundary, 8, interval);
+        assertPlan(smoothAtHalf, 8, interval);
+        assertEquals(smoothAtStart.tracks.get(0).colors.get(1),
+                smoothAtBoundary.tracks.get(0).colors.get(0));
+        assertEquals(Renderer.mix(smoothAtBoundary.tracks.get(0).colors.get(0),
+                        smoothAtBoundary.tracks.get(0).colors.get(1), 0.5),
+                smoothAtHalf.tracks.get(0).colors.get(0).intValue());
+        assertTrue(smoothAtHalf.tracks.get(0).colors.get(0)
+                != smoothAtBoundary.tracks.get(0).colors.get(0));
+        assertTrue(smoothAtHalf.tracks.get(0).colors.get(0)
+                != smoothAtBoundary.tracks.get(0).colors.get(1));
+        assertTrue(smoothAtBoundary.tracks.get(0).colors.get(0)
+                != smoothAtStart.tracks.get(0).colors.get(0));
+
+        JSONObject steppedCfg = config("mode", "random", "randomIntervalMs", interval,
+                "randomSmooth", false, "randomPerLed", false);
+        SequenceCompiler.Plan steppedAtStart = SequenceCompiler.compile(
+                steppedCfg, 0, 8, 25, 1.0, seed);
+        SequenceCompiler.Plan steppedAtBoundary = SequenceCompiler.compile(
+                steppedCfg, interval, 8, 25, 1.0, seed);
+        SequenceCompiler.Plan steppedAtHalf = SequenceCompiler.compile(
+                steppedCfg, interval + interval / 2, 8, 25, 1.0, seed);
+        assertPlan(steppedAtHalf, 8, interval);
+        assertEquals(steppedAtStart.tracks.get(0).colors.get(1),
+                steppedAtBoundary.tracks.get(0).colors.get(0));
+        assertEquals(steppedAtBoundary.tracks.get(0).colors.get(0),
+                steppedAtHalf.tracks.get(0).colors.get(0));
+        assertEquals(steppedAtBoundary.tracks.get(0).colors.get(1),
+                steppedAtHalf.tracks.get(0).colors.get(1));
+
+        SequenceCompiler.Plan scaledBoundary = SequenceCompiler.compile(
+                smoothCfg, interval, 8, 25, 0.5, seed);
+        SequenceCompiler.Plan scaledNextBoundary = SequenceCompiler.compile(
+                smoothCfg, interval * 2, 8, 25, 0.5, seed);
+        SequenceCompiler.Plan scaledHalf = SequenceCompiler.compile(
+                smoothCfg, interval + interval / 2, 8, 25, 0.5, seed);
+        assertEquals(Renderer.mix(scaledBoundary.tracks.get(0).colors.get(0),
+                        scaledNextBoundary.tracks.get(0).colors.get(0), 0.5),
+                scaledHalf.tracks.get(0).colors.get(0).intValue());
+        assertEquals(Renderer.scale(smoothAtBoundary.tracks.get(0).colors.get(0), 0.5),
+                scaledBoundary.tracks.get(0).colors.get(0).intValue());
+    }
+
+    @Test
+    public void blackTerminatorIsAnOpaqueClosedEightByTwoLinearPlan() {
+        SequenceCompiler.Plan plan = SequenceCompiler.blackTerminator(8, 66);
+        assertNotNull(plan);
+        assertEquals(66, plan.periodMs);
+        assertEquals(SequenceCompiler.Interpolation.LINEAR, plan.interpolation);
+        assertFalse(plan.mayLight());
+        assertEquals(8, plan.tracks.size());
+        for (SequenceCompiler.Track track : plan.tracks) {
+            assertEquals(2, track.points.size());
+            assertEquals(0, track.delaysMs.get(0).longValue());
+            assertEquals(66, track.delaysMs.get(1).longValue());
+            assertEquals(0xFF000000, track.colors.get(0).intValue());
+            assertEquals(0xFF000000, track.colors.get(1).intValue());
+        }
+        assertNull(SequenceCompiler.blackTerminator(0, 66));
+        assertNull(SequenceCompiler.blackTerminator(8, 0));
+        assertNull(SequenceCompiler.blackTerminator(37, 66));
+        assertNull(SequenceCompiler.blackTerminator(8, -1));
+    }
+
+    @Test
+    public void staticAndUnknownModesRejectForOrdinaryOutputHandling() throws Exception {
+        assertNull(SequenceCompiler.compile(config("mode", "off"), 0, 8, 25, 1.0));
+        assertNull(SequenceCompiler.compile(config("mode", "solid"), 0, 8, 25, 1.0));
+        assertNull(SequenceCompiler.compile(config("mode", "gradient"), 0, 8, 25, 1.0));
+        assertNull(SequenceCompiler.compile(config("mode", "custom", "rotateMs", 50),
+                0, 8, 25, 1.0));
+        assertNull(SequenceCompiler.compile(config("mode", "unknown"), 0, 8, 25, 1.0));
+        assertNull(SequenceCompiler.compile(null, 0, 8, 25, 1.0));
+    }
+
+    @Test
+    public void unsafeTimingAndTopologyRejectSafely() throws Exception {
+        assertNull(SequenceCompiler.compile(config("mode", "wave", "speedMs", 60),
+                0, 8, 61, 1.0));
+        assertNull(SequenceCompiler.compile(config("mode", "blink", "speedMs", 601),
+                0, 8, 301, 1.0));
+        assertNull(SequenceCompiler.compile(config("mode", "chase", "speedMs", 600),
+                0, 8, 76, 1.0));
+        assertNull(SequenceCompiler.compile(config("mode", "custom", "rotateMs", 100),
+                0, 8, 101, 1.0));
+        assertNull(SequenceCompiler.compile(config("mode", "random", "randomIntervalMs", 200),
+                0, 8, 201, 1.0));
+        assertNull(SequenceCompiler.compile(config("mode", "wave", "speedMs", 800),
+                0, 9, 40, 1.0));
+        assertNull(SequenceCompiler.compile(config("mode", "random", "randomIntervalMs", 200),
+                0, 9, 25, 1.0));
+    }
+
+    private static void assertPlan(SequenceCompiler.Plan plan, int ledCount, long quantum) {
+        assertNotNull(plan);
+        assertEquals(ledCount, plan.tracks.size());
+        int total = 0;
+        for (SequenceCompiler.Track track : plan.tracks) {
+            assertTrue(track.points.size() <= 9);
+            total += track.points.size();
+            assertEquals(0, track.delaysMs.get(0).longValue());
+            for (int i = 1; i < track.delaysMs.size(); i++) {
+                assertTrue(track.delaysMs.get(i) > 0);
+                assertTrue(track.delaysMs.get(i) >= quantum);
+            }
+            assertEquals(plan.periodMs, track.totalDurationMs());
+            assertEquals(track.colors.get(0),
+                    track.colors.get(track.colors.size() - 1));
+        }
+        assertTrue(total <= 72);
+    }
+
+    private static void assertPlansHaveSameColors(SequenceCompiler.Plan first,
+                                                    SequenceCompiler.Plan second) {
+        assertNotNull(second);
+        assertEquals(first.tracks.size(), second.tracks.size());
+        for (int i = 0; i < first.tracks.size(); i++) {
+            assertEquals(first.tracks.get(i).colors, second.tracks.get(i).colors);
+        }
+    }
+
+    private static void assertPlansHaveDifferentColors(SequenceCompiler.Plan first,
+                                                       SequenceCompiler.Plan second) {
+        assertNotNull(second);
+        boolean different = false;
+        for (int i = 0; i < first.tracks.size(); i++) {
+            different |= !first.tracks.get(i).colors.equals(second.tracks.get(i).colors);
+        }
+        assertTrue(different);
+    }
+
+    /* The Android unit-test class path supplies the framework's stub JSONObject.
+     * This tiny test double keeps these tests Android-free without changing the
+     * production build just to add a JSON test dependency. */
+    private static JSONObject config(Object... entries) throws Exception {
+        Field field = Class.forName("sun.misc.Unsafe").getDeclaredField("theUnsafe");
+        field.setAccessible(true);
+        Object unsafe = field.get(null);
+        TestConfig cfg = (TestConfig) unsafe.getClass()
+                .getMethod("allocateInstance", Class.class).invoke(unsafe, TestConfig.class);
+        cfg.values = new HashMap<>();
+        for (int i = 0; i < entries.length; i += 2) cfg.values.put((String) entries[i], entries[i + 1]);
+        return cfg;
+    }
+
+    private static final class TestConfig extends JSONObject {
+        private Map<String, Object> values;
+
+        @Override
+        public String optString(String name, String fallback) {
+            Object value = values.get(name);
+            return value == null ? fallback : String.valueOf(value);
+        }
+
+        @Override
+        public long optLong(String name, long fallback) {
+            Object value = values.get(name);
+            return value instanceof Number ? ((Number) value).longValue() : fallback;
+        }
+
+        @Override
+        public double optDouble(String name, double fallback) {
+            Object value = values.get(name);
+            return value instanceof Number ? ((Number) value).doubleValue() : fallback;
+        }
+
+        @Override
+        public boolean optBoolean(String name, boolean fallback) {
+            Object value = values.get(name);
+            return value instanceof Boolean ? (Boolean) value : fallback;
+        }
+
+        @Override
+        public org.json.JSONArray optJSONArray(String name) {
+            return null;
+        }
+    }
+}

--- a/core/src/com/hilight/core/Engine.java
+++ b/core/src/com/hilight/core/Engine.java
@@ -9,7 +9,7 @@ import org.json.JSONObject;
  * The alert layer wins while it lasts; a durationMs of 0 holds until the alert is replaced or the
  * "alert" key disappears. Everything else falls through to ambient.
  *
- * Ticks at the hardware's minimum update period (33 ms, ~30 fps).
+ * Ticks at the hardware's minimum update period (66 ms, ~15 fps).
  *
  * Nothing here runs forever, and the protections live here rather than in the UI so that no bug or
  * hostile state document can bypass them:
@@ -33,8 +33,13 @@ public final class Engine {
 
     public static final long FRAME_MS = SafetyGuard.FRAME_MS;
 
+    /** Device-validated waits for the preemptive black effect and its static-black drain. */
+    static final long BLACK_EFFECT_WAIT_MS = 2 * FRAME_MS;
+    static final long BLACK_STATIC_DRAIN_MS = FRAME_MS;
     /** Hard ceiling for a single alert, whatever the app asks for. */
     public static final long ALERT_MAX_MS = 60_000;
+    /** Matches the app's five-minute ambient timeout maximum. */
+    public static final long MAX_AMBIENT_TIMEOUT_MS = 300_000;
     public static final long DEFAULT_AMBIENT_TIMEOUT_MS = 30_000;
 
     /** Duty-cycle guard: at most half of any ten-minute window may be lit. */
@@ -50,6 +55,7 @@ public final class Engine {
     private final SafetyGuard safety = new SafetyGuard();
     private final OutputGate gate = new OutputGate();
     private final Object lock = new Object();
+    private long seedCounter;
 
     private Thread thread;
     private volatile boolean running;
@@ -58,9 +64,57 @@ public final class Engine {
     private JSONObject alert;
     private long alertId = -1;
     private boolean lastFrameWasAlert;
+    private long ambientGeneration;
 
     private double dim = 1.0;
     private long ambientTimeoutMs = DEFAULT_AMBIENT_TIMEOUT_MS;
+
+    private OutputGate.Layer lastLayer;
+    private Candidate candidate;
+    private Submission submission;
+    private boolean lastPushedBlack;
+    private boolean forceStaticPush;
+
+    private static final class Candidate {
+        final OutputGate.Layer layer;
+        final long alertId;
+        final long ambientGeneration;
+        final String config;
+        final long quantumMs;
+        final int ledCount;
+        final SequenceCompiler.Plan eligibility;
+        private final long randomSeed;
+
+        Candidate(OutputGate.Layer layer, long alertId, long ambientGeneration,
+                  String config, long quantumMs, int ledCount, long randomSeed,
+                  SequenceCompiler.Plan eligibility) {
+            this.layer = layer;
+            this.alertId = alertId;
+            this.ambientGeneration = ambientGeneration;
+            this.config = config;
+            this.quantumMs = quantumMs;
+            this.ledCount = ledCount;
+            this.randomSeed = randomSeed;
+            this.eligibility = eligibility;
+        }
+    }
+
+    private static final class Submission {
+        final Candidate candidate;
+        final double bucket;
+        final int priority;
+        final long coverageEnd;
+        final long periodMs;
+
+        Submission(Candidate candidate, double bucket, int priority,
+                   long coverageEnd, long periodMs) {
+            this.candidate = candidate;
+            this.bucket = bucket;
+            this.priority = priority;
+            this.coverageEnd = coverageEnd;
+            this.periodMs = periodMs;
+        }
+    }
 
     public void start() throws Exception {
         lights.connect();
@@ -81,7 +135,8 @@ public final class Engine {
     public void stop() {
         synchronized (lock) {
             running = false;
-            lights.push(new int[]{0});
+            invalidateEffects();
+            terminateActiveEffectToBlack();
             lights.closeSession();
         }
     }
@@ -98,9 +153,16 @@ public final class Engine {
             return;
         }
         synchronized (lock) {
+            JSONObject oldAmbient = state.optJSONObject("ambient");
+            String oldAmbientConfig = oldAmbient == null ? null : oldAmbient.toString();
             state = o;
-            ambientTimeoutMs = Math.max(1_000, o.optLong("ambientTimeoutMs", DEFAULT_AMBIENT_TIMEOUT_MS));
+            ambientTimeoutMs = clampAmbientTimeout(
+                    o.optLong("ambientTimeoutMs", DEFAULT_AMBIENT_TIMEOUT_MS));
             dim = Math.max(0.02, Math.min(1.0, o.optDouble("dim", 1.0)));
+            JSONObject newAmbient = o.optJSONObject("ambient");
+            String newAmbientConfig = newAmbient == null ? null : newAmbient.toString();
+            if (!same(oldAmbientConfig, newAmbientConfig)) ambientGeneration++;
+
             // Only a deliberate user action ("arm") may start a fresh window. Automatic pushes — an
             // alert firing, a foreground override, the app being backgrounded — must not, or the array
             // could be kept lit indefinitely in 30-second increments.
@@ -109,17 +171,20 @@ public final class Engine {
             // sends it, but the bootstrap file the app drops for a not-yet-running helper is just
             // {"enabled":false}, and defaulting to true let that open a window nobody asked for.
             if (o.optBoolean("arm", false)) gate.armAmbient(System.currentTimeMillis(), ambientTimeoutMs);
+
             JSONObject a = o.optJSONObject("alert");
             if (a == null) {
+                boolean hadAlert = alert != null || gate.isAlertHeld();
                 if (alert != null) Log.i("alert cleared");
                 alert = null;
                 alertId = -1;
                 // clears the blank latch too, so a cancelled alert cannot leave the array lit
                 gate.clearAlert();
                 renderer.reset();
+                if (hadAlert) invalidateEffects();
             } else {
                 long id = a.optLong("id", -1);
-                if (id != alertId) {
+                if (id != alertId || !same(a.toString(), alert == null ? null : alert.toString())) {
                     alertId = id;
                     alert = a;
                     long asked = a.optLong("durationMs", 4000);
@@ -127,6 +192,7 @@ public final class Engine {
                     long dur = asked <= 0 ? ambientTimeoutMs : Math.min(asked, ALERT_MAX_MS);
                     gate.startAlert(System.currentTimeMillis(), dur);
                     renderer.reset();
+                    invalidateEffects();
                     Log.i("alert " + id + " " + a.optString("pattern", "pulse") + " for " + dur + "ms"
                             + (dur != asked ? " (asked " + asked + ", capped)" : ""));
                 }
@@ -153,6 +219,8 @@ public final class Engine {
                 o.put("ambientHeld", gate.isAmbientHeld());
                 o.put("resting", safety.isResting());
                 o.put("dutyPct", safety.dutyPercent());
+                o.put("hardwareEffect", lights.isEffectActive());
+                o.put("hardwareEffectSupport", lights.supportsEffects());
                 o.put("version", 1);
             }
         } catch (Exception ignored) {
@@ -162,20 +230,34 @@ public final class Engine {
     }
 
     private void loop() {
-        while (running) {
-            try {
-                tick();
-                Thread.sleep(FRAME_MS);
-            } catch (InterruptedException e) {
-                return;
-            } catch (Throwable t) {
-                Log.w("frame failed: " + t);
+        boolean interrupted = false;
+        try {
+            while (running) {
                 try {
-                    Thread.sleep(250);
+                    tick();
+                    Thread.sleep(FRAME_MS);
                 } catch (InterruptedException e) {
-                    return;
+                    interrupted = true;
+                    break;
+                } catch (Throwable t) {
+                    Log.w("frame failed: " + t);
+                    try {
+                        Thread.sleep(250);
+                    } catch (InterruptedException e) {
+                        interrupted = true;
+                        break;
+                    }
                 }
             }
+        } finally {
+            synchronized (lock) {
+                running = false;
+                invalidateEffects();
+                // Last defense against closing/leaving a colored effect on a thread exit.
+                terminateActiveEffectToBlack();
+                lights.closeSession();
+            }
+            if (interrupted) Thread.currentThread().interrupt();
         }
     }
 
@@ -184,22 +266,37 @@ public final class Engine {
             if (!running) return;                   // stop() may have closed the session already
             boolean enabled = state.optBoolean("enabled", false);
             int priority = state.optInt("priority", 0);
+            long now = now();
 
             if (!enabled) {
+                invalidateEffects();
                 release("released HiLight to the system");
-                noteDark(now());
+                noteDark(now);
                 return;
             }
 
-            long now = System.currentTimeMillis();
             OutputGate.Layer layer = gate.next(now);
-
+            if (layer != lastLayer) {
+                invalidateEffects();
+                lastLayer = layer;
+            }
             if (lastFrameWasAlert && layer != OutputGate.Layer.ALERT) {
                 alert = null;
                 renderer.reset();
                 // deliberately no re-arm here: an alert must not extend the ambient window
+                invalidateEffects();
             }
             lastFrameWasAlert = layer == OutputGate.Layer.ALERT;
+
+            // OutputGate keeps the endpoint frame at equality for compatibility; do not let that
+            // zero-remaining frame become a colored software tail. Treat the exact deadline as the
+            // dark transition and perform the same guarded release transaction.
+            if (layer == OutputGate.Layer.AMBIENT && gate.ambientRemainingMs(now) <= 0) {
+                invalidateEffects();
+                noteDark(now);
+                release("ambient window expired — released HiLight to the system");
+                return;
+            }
 
             JSONObject cfg;
             long t;
@@ -213,25 +310,119 @@ public final class Engine {
                     t = now;
                     break;
                 case BLANK:
-                    // Blank, then let go. Holding an all-black session would keep winning over the
-                    // system's own HiLight effects, so calls and Gemini would stay dark for as long
-                    // as this process lived — and it outlives the app, so only a reboot fixed it.
-                    if (lights.isSessionOpen()) lights.push(protect(new int[]{0}, now));
+                    invalidateEffects();
+                    if (lights.isSessionOpen()) terminateActiveEffectToBlack();
+                    return;
+                default:                                    // IDLE: dark, now hand the array back
+                    invalidateEffects();
+                    noteDark(now);
                     release("nothing left to show — released HiLight to the system");
                     return;
-                default:                                    // IDLE: dark, and already handed back
-                    noteDark(now);
-                    return;
             }
+
             // The session is taken only while there is something to show, and reopened on demand: a
             // rule firing lands here and gets it back before the first frame.
             if (!lights.isSessionOpen() || priority != lights.sessionPriority()) {
-                if (lights.isSessionOpen()) lights.closeSession();
+                invalidateEffects();
+                if (lights.isSessionOpen()) {
+                    terminateActiveEffectToBlack();
+                    lights.closeSession();
+                }
                 lights.openSession(priority);
+                lastPushedBlack = false;
             }
-            int[] frame = renderer.frame(cfg, t, Math.max(1, lights.ledCount()));
-            lights.push(protect(frame, now));
+
+            int ledCount = Math.max(1, lights.ledCount());
+            long quantum = lights.effectQuantumMs();
+            if (quantum > 0 && cfg != null) {
+                Candidate current = candidateFor(layer, cfg, quantum, ledCount);
+                if (current.eligibility != null && current.eligibility.mayLight()) {
+                    SafetyGuard.Decision decision = safety.observe(true, now, dim);
+                    double bucket = scaleBucket(decision.scale);
+                    if (!decision.resting && bucket > 0.0
+                            && submitHardware(current, cfg, t, bucket, priority,
+                            gateRemaining(layer, now), now)) {
+                        return;
+                    }
+                    // A resting/zero plan, or a scaled plan that could not be built, must cancel
+                    // any finite effect with this frame. The decision was already observed above.
+                    renderSoftware(cfg, t, now, decision);
+                    return;
+                }
+            }
+
+            // Static, unsupported and compiler-capped patterns retain the ordinary path.
+            renderSoftware(cfg, t, now, null);
         }
+    }
+
+    private Candidate candidateFor(OutputGate.Layer layer, JSONObject cfg,
+                                   long quantum, int ledCount) {
+        String config = cfg.toString();
+        long id = layer == OutputGate.Layer.ALERT ? alertId : -1;
+        if (candidate != null && candidate.layer == layer && candidate.alertId == id
+                && candidate.ambientGeneration == ambientGeneration
+                && candidate.quantumMs == quantum && candidate.ledCount == ledCount
+                && same(candidate.config, config)) {
+            return candidate;
+        }
+        long randomSeed = nextRandomSeed();
+        SequenceCompiler.Plan eligibility = SequenceCompiler.compile(
+                cfg, 0, ledCount, quantum, 1.0, randomSeed);
+        candidate = new Candidate(layer, id, ambientGeneration, config, quantum, ledCount,
+                randomSeed, eligibility);
+        submission = null;
+        return candidate;
+    }
+
+    private boolean submitHardware(Candidate current, JSONObject cfg, long phase,
+                                   double bucket, int priority, long remainingMs, long now) {
+        long period = current.eligibility.periodMs;
+        long requiredCoverageEnd = requiredCoverageEnd(now, remainingMs);
+        if (submission != null) {
+            boolean candidateMatches = submission.candidate == current;
+            boolean bucketMatches = submission.bucket == bucket;
+            boolean priorityMatches = submission.priority == priority;
+            boolean periodMatches = submission.periodMs == period;
+            boolean localEffectActive = lights.isEffectActive();
+            if (shouldReuseHardwareSubmission(candidateMatches, bucketMatches,
+                    priorityMatches, periodMatches, localEffectActive, submission.coverageEnd,
+                    requiredCoverageEnd, remainingMs, period)) {
+                return true;
+            }
+        }
+
+        int iterations = effectIterations(remainingMs, period);
+        if (iterations <= 0) return false;
+        long coverageEnd = coverageEnd(now, iterations, period);
+        SequenceCompiler.Plan plan = SequenceCompiler.compile(cfg, phase,
+                current.ledCount, current.quantumMs, bucket, current.randomSeed);
+        if (plan == null || !plan.mayLight()) return false;
+        if (!lights.startEffect(plan, iterations)) {
+            submission = null;
+            forceStaticPush = true;
+            return false;
+        }
+        submission = new Submission(current, bucket, priority, coverageEnd, period);
+        return true;
+    }
+
+    private long gateRemaining(OutputGate.Layer layer, long now) {
+        return layer == OutputGate.Layer.ALERT
+                ? gate.alertRemainingMs(now) : gate.ambientRemainingMs(now);
+    }
+
+    private void renderSoftware(JSONObject cfg, long t, long now, SafetyGuard.Decision decision) {
+        submission = null;
+        int[] frame = renderer.frame(cfg, t, Math.max(1, lights.ledCount()));
+        int[] protectedFrame = decision == null
+                ? protect(frame, now) : safety.apply(frame, decision);
+        if (lights.isEffectActive() && isDark(protectedFrame)) {
+            terminateActiveEffectToBlack();
+        } else {
+            pushStatic(protectedFrame, forceStaticPush || lights.isEffectActive());
+        }
+        forceStaticPush = false;
     }
 
     /**
@@ -256,9 +447,177 @@ public final class Engine {
 
     /** Hands the array back to Android, if we are holding it. */
     private void release(String why) {
+        invalidateEffects();
         if (!lights.isSessionOpen()) return;
+        terminateActiveEffectToBlack();
         lights.closeSession();
+        lastPushedBlack = false;
         Log.i(why);
+    }
+
+    /**
+     * Cancels a colored hardware effect with the validated preemptive black effect, then drains a
+     * static-black frame before the session can be released. This is intentionally one best-effort
+     * transaction: a failed black submission falls back to static black and is never retried here.
+     */
+    private void terminateActiveEffectToBlack() {
+        if (!lights.isSessionOpen()) return;
+
+        // A successful prior transaction already ended with a static black push. Do not submit or
+        // drain again when the following IDLE/release transition closes that same session.
+        if (!lights.isEffectActive()) {
+            if (lastPushedBlack) return;
+            pushStatic(BLANK, true);
+            boolean interrupted = sleepPreservingInterrupt(BLACK_STATIC_DRAIN_MS);
+            if (interrupted) Thread.interrupted();
+            if (interrupted) Thread.currentThread().interrupt();
+            return;
+        }
+
+        boolean interrupted = false;
+        SequenceCompiler.Plan terminator = SequenceCompiler.blackTerminator(
+                lights.ledCount(), FRAME_MS);
+        if (terminator != null && lights.startEffect(terminator, 1)) {
+            interrupted |= sleepPreservingInterrupt(BLACK_EFFECT_WAIT_MS);
+            if (interrupted) Thread.interrupted();
+        }
+        // This is also the fallback when the preemptive black submission is rejected or fails.
+        pushStatic(BLANK, true);
+        boolean staticDrainInterrupted = sleepPreservingInterrupt(BLACK_STATIC_DRAIN_MS);
+        interrupted |= staticDrainInterrupted;
+        if (staticDrainInterrupted) Thread.interrupted();
+        if (interrupted) Thread.currentThread().interrupt();
+    }
+
+    private void invalidateEffects() {
+        candidate = null;
+        submission = null;
+    }
+
+    private void pushStatic(int[] frame, boolean force) {
+        if (!lights.isSessionOpen()) return;
+        boolean black = isDark(frame);
+        if (black && !force && lastPushedBlack) return;
+        lights.push(frame);
+        lastPushedBlack = black;
+    }
+
+    private static boolean isDark(int[] frame) {
+        for (int color : frame) {
+            if (((color >> 16 & 0xFF) + (color >> 8 & 0xFF) + (color & 0xFF)) > 12) return false;
+        }
+        return true;
+    }
+
+    /** Returns whether a matching active effect covers the exact finite gate deadline. */
+    static boolean isHardwareSubmissionLive(boolean candidateMatches, boolean bucketMatches,
+                                             boolean priorityMatches, boolean periodMatches,
+                                             boolean localEffectActive, long coverageEnd,
+                                             long requiredCoverageEnd) {
+        return candidateMatches && bucketMatches && priorityMatches && periodMatches
+                && localEffectActive && coverageEnd >= requiredCoverageEnd;
+    }
+
+    /**
+     * Returns whether the cached colored effect may remain in place for this frame.
+     *
+     * A taper bucket change normally requires a replacement. Reuse the current effect when a full
+     * replacement cycle cannot fit before the gate deadline; otherwise the changed scale is allowed
+     * to replace it normally. Matching buckets retain the ordinary reuse policy at any remaining
+     * time.
+     *
+     * The period is passed separately from periodMatches because the cycle-fit rule depends on the
+     * actual positive period, not merely on whether the cached period identity matches.
+     */
+    static boolean shouldReuseHardwareSubmission(boolean candidateMatches, boolean bucketMatches,
+                                                  boolean priorityMatches, boolean periodMatches,
+                                                  boolean localEffectActive, long coverageEnd,
+                                                  long requiredCoverageEnd, long remainingMs,
+                                                  long periodMs) {
+        if (!candidateMatches || !priorityMatches || !periodMatches || !localEffectActive
+                || coverageEnd < requiredCoverageEnd) {
+            return false;
+        }
+        if (bucketMatches) return true;
+        if (periodMs <= 0) return false;
+        long nonNegativeRemainingMs = Math.max(0, remainingMs);
+        return nonNegativeRemainingMs < periodMs;
+    }
+
+    static long requiredCoverageEnd(long now, long remainingMs) {
+        return saturatingAdd(now, Math.max(0, remainingMs));
+    }
+
+    /** Bounds hostile or malformed state before it reaches the output gate. */
+    static long clampAmbientTimeout(long requestedTimeoutMs) {
+        if (requestedTimeoutMs < 1_000) return 1_000;
+        return Math.min(requestedTimeoutMs, MAX_AMBIENT_TIMEOUT_MS);
+    }
+
+    /** Number of periods needed to cover the finite gate deadline, rounded upward. */
+    static int effectIterations(long remainingMs, long periodMs) {
+        if (remainingMs <= 0 || periodMs <= 0) return 0;
+        long quotient = remainingMs / periodMs;
+        long count = remainingMs % periodMs == 0 ? quotient : quotient + 1;
+        return count >= Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) count;
+    }
+
+    /** Saturated end time for the finite effect actually submitted. */
+    static long coverageEnd(long now, int iterations, long period) {
+        if (iterations <= 0 || period <= 0) return now;
+        long span = iterations > Long.MAX_VALUE / period ? Long.MAX_VALUE : iterations * period;
+        return saturatingAdd(now, span);
+    }
+
+    private static long saturatingAdd(long first, long second) {
+        if (second > 0 && first > Long.MAX_VALUE - second) return Long.MAX_VALUE;
+        if (second < 0 && first < Long.MIN_VALUE - second) return Long.MIN_VALUE;
+        return first + second;
+    }
+
+    /** Sleeps for the requested duration even when interrupted, preserving the status. */
+    static boolean sleepPreservingInterrupt(long durationMs) {
+        if (durationMs <= 0) return false;
+        long deadline = System.nanoTime() + durationMs * 1_000_000L;
+        boolean interrupted = false;
+        for (;;) {
+            long remainingNanos = deadline - System.nanoTime();
+            if (remainingNanos <= 0) {
+                if (interrupted) Thread.currentThread().interrupt();
+                return interrupted;
+            }
+            long millis = remainingNanos / 1_000_000L;
+            int nanos = (int) (remainingNanos % 1_000_000L);
+            try {
+                Thread.sleep(millis, nanos);
+            } catch (InterruptedException e) {
+                interrupted = true;
+            }
+        }
+    }
+
+    static double scaleBucket(double scale) {
+        if (!Double.isFinite(scale) || scale <= 0) return 0;
+        double bucket = Math.floor((scale + 1e-9) * 20.0) / 20.0;
+        return bucket < 0.0 ? 0.0 : bucket > 1.0 ? 1.0 : bucket;
+    }
+
+    private static boolean same(String a, String b) {
+        return a == null ? b == null : a.equals(b);
+    }
+
+    private long nextRandomSeed() {
+        long counter = ++seedCounter;
+        return mixSeed(counter, System.nanoTime(), System.identityHashCode(this));
+    }
+
+    /** Deterministic mixer for the per-candidate random activation seed. */
+    static long mixSeed(long counter, long timeNanos, int identityHash) {
+        long value = counter * 0x9E3779B97F4A7C15L
+                ^ timeNanos ^ ((long) identityHash * 0xBF58476D1CE4E5B9L);
+        value = (value ^ (value >>> 30)) * 0xBF58476D1CE4E5B9L;
+        value = (value ^ (value >>> 27)) * 0x94D049BB133111EBL;
+        return value ^ (value >>> 31);
     }
 
     private static long now() {

--- a/core/src/com/hilight/core/LightsBackend.java
+++ b/core/src/com/hilight/core/LightsBackend.java
@@ -1,11 +1,18 @@
 package com.hilight.core;
 
+import android.hardware.lights.ColorSequence;
 import android.hardware.lights.Light;
 import android.hardware.lights.LightState;
+import android.hardware.lights.MultiLightEffect;
 import android.os.Binder;
+import android.os.Build;
 import android.os.IBinder;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 /**
@@ -21,12 +28,107 @@ import java.util.List;
  */
 public final class LightsBackend {
 
+    static final String CERTIFIED_FINGERPRINT =
+            "google/kodiak/kodiak:17/CD1A.260714.001.A9/15938155:user/release-keys";
+    private static final int CERTIFIED_LIGHT_COUNT = 8;
+    private static final int MAX_DESCRIBED_APPLICATION_LIGHTS = 32;
+
     private final IBinder token = new Binder();
     private Object service;
-    private Method mGetLights, mOpenSession, mCloseSession, mSetLightStates;
+    private Method mGetLights, mOpenSession, mCloseSession, mSetLightStates, mSetLightEffect;
     private int[] ids = new int[0];
+    private final List<Light> applicationLights = new ArrayList<>();
     private boolean sessionOpen;
     private int sessionPriority = Integer.MIN_VALUE;
+    private boolean effectActive;
+    private boolean effectsDisabled;
+    private boolean effectsCertified;
+    private long certifiedQuantumMs;
+
+    /** Internal adapter used to read capabilities without coupling the safe reader to Light. */
+    interface CapabilitySource {
+        int id();
+        boolean hasRgbControl();
+        boolean hasAnimationControl();
+        long getMinUpdatePeriodMillis();
+    }
+
+    /** Package-private model keeps topology even when an individual capability is unavailable. */
+    static final class CapabilityRead {
+        final int[] ids;
+        final boolean[] rgbControl;
+        final boolean[] animationControl;
+        final long[] minUpdatePeriods;
+        final boolean[] rgbKnown;
+        final boolean[] animationKnown;
+        final boolean[] minUpdatePeriodKnown;
+        final boolean capabilitiesKnown;
+        final long quantumMs;
+
+        CapabilityRead(int[] ids, boolean[] rgbControl, boolean[] animationControl,
+                       long[] minUpdatePeriods, boolean[] rgbKnown,
+                       boolean[] animationKnown, boolean[] minUpdatePeriodKnown,
+                       boolean capabilitiesKnown, long quantumMs) {
+            this.ids = ids;
+            this.rgbControl = rgbControl;
+            this.animationControl = animationControl;
+            this.minUpdatePeriods = minUpdatePeriods;
+            this.rgbKnown = rgbKnown;
+            this.animationKnown = animationKnown;
+            this.minUpdatePeriodKnown = minUpdatePeriodKnown;
+            this.capabilitiesKnown = capabilitiesKnown;
+            this.quantumMs = quantumMs;
+        }
+    }
+
+    /** Reads each required getter independently; a failure is conservative but non-fatal. */
+    static CapabilityRead readCapabilities(List<? extends CapabilitySource> sources) {
+        int count = sources == null ? 0 : sources.size();
+        int[] ids = new int[count];
+        boolean[] rgb = new boolean[count];
+        boolean[] animation = new boolean[count];
+        long[] periods = new long[count];
+        boolean[] rgbKnown = new boolean[count];
+        boolean[] animationKnown = new boolean[count];
+        boolean[] periodKnown = new boolean[count];
+        boolean known = true;
+        for (int i = 0; i < count; i++) {
+            CapabilitySource source = sources.get(i);
+            ids[i] = source.id();
+            try {
+                rgb[i] = source.hasRgbControl();
+                rgbKnown[i] = true;
+            } catch (Throwable ignored) {
+                known = false;
+            }
+            try {
+                animation[i] = source.hasAnimationControl();
+                animationKnown[i] = true;
+            } catch (Throwable ignored) {
+                known = false;
+            }
+            try {
+                periods[i] = source.getMinUpdatePeriodMillis();
+                periodKnown[i] = true;
+            } catch (Throwable ignored) {
+                known = false;
+            }
+        }
+        return new CapabilityRead(ids, rgb, animation, periods, rgbKnown,
+                animationKnown, periodKnown, known,
+                known ? slowestPositivePeriod(periods) : 0);
+    }
+
+    private static CapabilitySource capabilitySource(final Light light) {
+        return new CapabilitySource() {
+            @Override public int id() { return light.getId(); }
+            @Override public boolean hasRgbControl() { return light.hasRgbControl(); }
+            @Override public boolean hasAnimationControl() { return light.hasAnimationControl(); }
+            @Override public long getMinUpdatePeriodMillis() {
+                return light.getMinUpdatePeriodMillis();
+            }
+        };
+    }
 
     public void connect() throws Exception {
         IBinder b = (IBinder) Class.forName("android.os.ServiceManager")
@@ -39,15 +141,43 @@ public final class LightsBackend {
         mOpenSession = iface.getMethod("openSession", IBinder.class, int.class);
         mCloseSession = iface.getMethod("closeSession", IBinder.class);
         mSetLightStates = iface.getMethod("setLightStates", IBinder.class, int[].class, LightState[].class);
+        mSetLightEffect = null;
+        try {
+            mSetLightEffect = iface.getMethod("setLightEffect", IBinder.class,
+                    MultiLightEffect.class);
+        } catch (NoSuchMethodException missingEffectMethod) {
+            // The final certification log below reports the single policy reason.
+        }
 
         @SuppressWarnings("unchecked")
         List<Light> all = (List<Light>) mGetLights.invoke(service);
-        int n = 0;
-        for (Light l : all) if (l.getType() == Light.LIGHT_TYPE_APPLICATION) n++;
-        ids = new int[n];
-        int k = 0;
-        for (Light l : all) if (l.getType() == Light.LIGHT_TYPE_APPLICATION) ids[k++] = l.getId();
+        applicationLights.clear();
+        for (Light l : all) {
+            if (l.getType() == Light.LIGHT_TYPE_APPLICATION) applicationLights.add(l);
+        }
+        Collections.sort(applicationLights, Comparator.comparingInt(Light::getId));
+        List<CapabilitySource> capabilitySources = new ArrayList<>(applicationLights.size());
+        for (Light light : applicationLights) capabilitySources.add(capabilitySource(light));
+        CapabilityRead capabilities = readCapabilities(capabilitySources);
+        ids = capabilities.ids;
+        effectActive = false;
+        effectsDisabled = false;
+        certifiedQuantumMs = capabilities.quantumMs;
+        effectsCertified = mSetLightEffect != null && capabilities.capabilitiesKnown
+                && isCertifiedProfile(Build.FINGERPRINT, capabilities.ids,
+                capabilities.rgbControl, capabilities.animationControl,
+                capabilities.minUpdatePeriods);
         describe(all);
+        if (mSetLightEffect == null) {
+            Log.i("hardware effects disabled: setLightEffect unavailable");
+        } else if (!CERTIFIED_FINGERPRINT.equals(Build.FINGERPRINT)) {
+            Log.i("hardware effects disabled: uncertified fingerprint");
+        } else if (!effectsCertified) {
+            Log.i("hardware effects disabled: uncertified application-light topology/capability");
+        } else {
+            Log.i("hardware effects certified: Pixel 8-light profile, quantum="
+                    + certifiedQuantumMs + "ms");
+        }
     }
 
     /**
@@ -59,31 +189,89 @@ public final class LightsBackend {
      * ids and colours but nothing about control.
      */
     private void describe(List<Light> all) {
+        int described = 0;
+        int omitted = 0;
         for (Light l : all) {
             if (l.getType() != Light.LIGHT_TYPE_APPLICATION) continue;
-            String period;
+            if (described >= MAX_DESCRIBED_APPLICATION_LIGHTS) {
+                omitted++;
+                continue;
+            }
+            CapabilityRead capabilities = readCapabilities(
+                    Collections.singletonList(capabilitySource(l)));
+            String rgb = capabilities.rgbKnown[0]
+                    ? Boolean.toString(capabilities.rgbControl[0]) : "unknown";
+            String animation = capabilities.animationKnown[0]
+                    ? Boolean.toString(capabilities.animationControl[0]) : "unknown";
+            String period = capabilities.minUpdatePeriodKnown[0]
+                    ? capabilities.minUpdatePeriods[0] + "ms" : "unknown";
+            String brightness;
             try {
-                period = l.getMinUpdatePeriodMillis() + "ms";
-            } catch (Throwable t) {
-                period = "unknown";
+                brightness = Boolean.toString(l.hasBrightnessControl());
+            } catch (Throwable ignored) {
+                brightness = "unknown";
             }
             Log.i("light id=" + l.getId()
                     + " ordinal=" + l.getOrdinal()
                     + " type=" + l.getType()
-                    + " rgb=" + l.hasRgbControl()
-                    + " brightness=" + l.hasBrightnessControl()
-                    + " animation=" + l.hasAnimationControl()
+                    + " rgb=" + rgb
+                    + " brightness=" + brightness
+                    + " animation=" + animation
                     + " minUpdatePeriod=" + period);
+            described++;
         }
+        if (omitted > 0) Log.i("light capability description truncated: omitted=" + omitted);
     }
 
     public int ledCount() { return ids.length; }
+
+    public boolean supportsEffects() { return effectQuantumMs() > 0; }
+
+    /** Returns the certified profile's slowest minimum update period, or zero when unsupported. */
+    public long effectQuantumMs() {
+        if (effectsDisabled || !effectsCertified) return 0;
+        return certifiedQuantumMs;
+    }
+
+    /** Pure profile policy; capability arrays may arrive in any order and are matched by id. */
+    static boolean isCertifiedProfile(String fingerprint, int[] lightIds,
+                                      boolean[] rgbControl, boolean[] animationControl,
+                                      long[] minUpdatePeriods) {
+        if (!CERTIFIED_FINGERPRINT.equals(fingerprint)
+                || lightIds == null || rgbControl == null || animationControl == null
+                || minUpdatePeriods == null
+                || lightIds.length != CERTIFIED_LIGHT_COUNT
+                || rgbControl.length != CERTIFIED_LIGHT_COUNT
+                || animationControl.length != CERTIFIED_LIGHT_COUNT
+                || minUpdatePeriods.length != CERTIFIED_LIGHT_COUNT) return false;
+        for (int expectedId = 1; expectedId <= CERTIFIED_LIGHT_COUNT; expectedId++) {
+            int found = -1;
+            for (int i = 0; i < lightIds.length; i++) {
+                if (lightIds[i] == expectedId) {
+                    if (found != -1) return false;
+                    found = i;
+                }
+            }
+            if (found == -1 || !rgbControl[found] || !animationControl[found]
+                    || minUpdatePeriods[found] <= 0) return false;
+        }
+        return true;
+    }
+
+    private static long slowestPositivePeriod(long[] periods) {
+        long slowest = 0;
+        for (long period : periods) slowest = Math.max(slowest, period);
+        return slowest;
+    }
+
+    public boolean isEffectActive() { return effectActive; }
 
     public boolean isSessionOpen() { return sessionOpen; }
 
     public int sessionPriority() { return sessionPriority; }
 
     public void openSession(int priority) {
+        effectActive = false;
         try {
             mOpenSession.invoke(service, token, priority);
             sessionOpen = true;
@@ -94,6 +282,7 @@ public final class LightsBackend {
     }
 
     public void closeSession() {
+        effectActive = false;
         if (!sessionOpen) return;
         try {
             mCloseSession.invoke(service, token);
@@ -101,6 +290,115 @@ public final class LightsBackend {
             Log.w("closeSession failed: " + e);
         }
         sessionOpen = false;
+    }
+
+    /** Submits one finite, preemptive hardware effect. */
+    public boolean startEffect(SequenceCompiler.Plan plan, int iterations) {
+        if (!sessionOpen || iterations <= 0 || plan == null || !supportsEffects()
+                || applicationLights.size() != CERTIFIED_LIGHT_COUNT
+                || !isEffectPlanSafe(plan, certifiedQuantumMs, iterations)) {
+            return false;
+        }
+        try {
+            MultiLightEffect.Builder effectBuilder = new MultiLightEffect.Builder();
+            int interpolation = plan.interpolation == SequenceCompiler.Interpolation.LINEAR
+                    ? ColorSequence.INTERPOLATION_MODE_LINEAR
+                    : ColorSequence.INTERPOLATION_MODE_NONE;
+            for (int i = 0; i < applicationLights.size(); i++) {
+                SequenceCompiler.Track track = plan.tracks.get(i);
+                ColorSequence.Builder sequenceBuilder = new ColorSequence.Builder();
+                for (SequenceCompiler.Point point : track.points) {
+                    sequenceBuilder.addControlPoint(point.delayMs, point.color);
+                }
+                ColorSequence sequence = sequenceBuilder
+                        .setInterpolationMode(interpolation)
+                        .build();
+                effectBuilder.addLightSequence(applicationLights.get(i), sequence);
+            }
+            MultiLightEffect effect = effectBuilder.setIterations(iterations)
+                    .setPreemptive(true)
+                    .build();
+            mSetLightEffect.invoke(service, token, effect);
+            effectActive = true;
+            Log.i("hardware effect started: lights=" + applicationLights.size()
+                    + " iterations=" + iterations + " period=" + plan.periodMs + "ms"
+                    + " interpolation=" + plan.interpolation);
+            return true;
+        } catch (Throwable failure) {
+            effectActive = false;
+            effectsDisabled = true;
+            Log.w("hardware effects disabled after failure: " + rootCause(failure));
+            return false;
+        }
+    }
+
+    /** Pure defensive check immediately before any MultiLightEffect builder is touched. */
+    static boolean isEffectPlanSafe(SequenceCompiler.Plan plan, long quantumMs, int iterations) {
+        if (plan == null || plan.tracks == null
+                || plan.tracks.size() != CERTIFIED_LIGHT_COUNT) return false;
+        try {
+            long[][] delays = new long[CERTIFIED_LIGHT_COUNT][];
+            int[][] colors = new int[CERTIFIED_LIGHT_COUNT][];
+            for (int i = 0; i < CERTIFIED_LIGHT_COUNT; i++) {
+                SequenceCompiler.Track track = plan.tracks.get(i);
+                if (track == null || track.points == null
+                        || track.points.size() < 1 || track.points.size() > 9) return false;
+                delays[i] = new long[track.points.size()];
+                colors[i] = new int[track.points.size()];
+                for (int j = 0; j < track.points.size(); j++) {
+                    SequenceCompiler.Point point = track.points.get(j);
+                    if (point == null) return false;
+                    delays[i][j] = point.delayMs;
+                    colors[i][j] = point.color;
+                }
+            }
+            return isEffectPlanSafe(plan.periodMs, plan.interpolation, delays, colors,
+                    quantumMs, iterations);
+        } catch (RuntimeException malformedPlan) {
+            return false;
+        }
+    }
+
+    /** Pure array policy used by JVM tests without constructing framework Light/Binder objects. */
+    static boolean isEffectPlanSafe(long periodMs, SequenceCompiler.Interpolation interpolation,
+                                    long[][] delays, int[][] colors, long quantumMs,
+                                    int iterations) {
+        if (periodMs <= 0 || quantumMs <= 0 || iterations <= 0
+                || interpolation == null
+                || (interpolation != SequenceCompiler.Interpolation.LINEAR
+                && interpolation != SequenceCompiler.Interpolation.NONE)
+                || delays == null || colors == null
+                || delays.length != CERTIFIED_LIGHT_COUNT
+                || colors.length != CERTIFIED_LIGHT_COUNT) return false;
+        int total = 0;
+        for (int light = 0; light < delays.length; light++) {
+            long[] trackDelays = delays[light];
+            int[] trackColors = colors[light];
+            if (trackDelays == null || trackColors == null
+                    || trackDelays.length != trackColors.length
+                    || trackDelays.length < 1 || trackDelays.length > 9) return false;
+            if (total > 72 - trackDelays.length) return false;
+            total += trackDelays.length;
+            if (trackDelays[0] != 0
+                    || trackColors[0] != trackColors[trackColors.length - 1]) return false;
+            long duration = 0;
+            for (int point = 0; point < trackDelays.length; point++) {
+                long delay = trackDelays[point];
+                if (point > 0 && (delay <= 0 || delay < quantumMs)) return false;
+                if (delay > Long.MAX_VALUE - duration) return false;
+                duration += delay;
+            }
+            if (duration != periodMs) return false;
+        }
+        return total <= 72;
+    }
+
+    private static String rootCause(Throwable failure) {
+        Throwable root = failure;
+        while (root instanceof InvocationTargetException && root.getCause() != null) {
+            root = root.getCause();
+        }
+        return root.toString();
     }
 
     /** Pushes one frame. [colors] is indexed per LED; a shorter array is repeated. */
@@ -112,6 +410,7 @@ public final class LightsBackend {
         }
         try {
             mSetLightStates.invoke(service, token, ids, st);
+            effectActive = false;
         } catch (Exception e) {
             Log.w("setLightStates failed: " + e);
             // Tell the service the session is over before dropping the local flag. A transient

--- a/core/src/com/hilight/core/OutputGate.java
+++ b/core/src/com/hilight/core/OutputGate.java
@@ -7,8 +7,8 @@ package com.hilight.core;
  * Pure and Android-free for the same reason as {@link SafetyGuard}: the rules that stop the array
  * being left lit are the part worth testing directly, and they are easy to get subtly wrong.
  *
- * The blank latch exists only to avoid pushing a blank frame every 33 ms once the array is already
- * dark — {@link LightsBackend#push} is a binder call with no dedup of its own. The latch therefore
+ * The blank latch exists only to avoid pushing a blank frame every render tick once the array is
+ * already dark — {@link LightsBackend#push} is a binder call with no dedup of its own. The latch therefore
  * has to describe the hardware, not the reason it went dark, which is why {@link #clearAlert()}
  * resets it: an alert leaves the LEDs lit, so one more blank frame is owed after it ends.
  */
@@ -66,6 +66,10 @@ final class OutputGate {
 
     long alertElapsed(long now) {
         return now - alertStart;
+    }
+
+    long alertRemainingMs(long now) {
+        return alertHeld ? Math.max(0, alertEnd - now) : 0;
     }
 
     long ambientRemainingMs(long now) {

--- a/core/src/com/hilight/core/SafetyGuard.java
+++ b/core/src/com/hilight/core/SafetyGuard.java
@@ -7,7 +7,7 @@ package com.hilight.core;
  */
 final class SafetyGuard {
 
-    static final long FRAME_MS = 33;
+    static final long FRAME_MS = 66;
     static final long DUTY_WINDOW_MS = 10 * 60_000;
     static final double MAX_DUTY = 0.5;
     static final long TAPER_AFTER_MS = 10_000;
@@ -25,6 +25,21 @@ final class SafetyGuard {
     private long litMsInWindow;
     private long continuousLitMs;
     private boolean resting;
+
+    /** The safety decision for one frame/effect interval. */
+    static final class Decision {
+        final double scale;
+        final boolean resting;
+        private final double quietScale;
+        private final double taper;
+
+        private Decision(double scale, boolean resting, double quietScale, double taper) {
+            this.scale = scale;
+            this.resting = resting;
+            this.quietScale = quietScale;
+            this.taper = taper;
+        }
+    }
 
     SafetyGuard() {
         this(FRAME_MS, DUTY_WINDOW_MS, MAX_DUTY, TAPER_AFTER_MS, TAPER_RAMP_MS, TAPER_FLOOR);
@@ -51,48 +66,77 @@ final class SafetyGuard {
     }
 
     int[] apply(int[] frame, long now, double dim) {
+        return apply(frame, observe(isLit(frame), now, dim));
+    }
+
+    /** Applies an already-observed decision without charging duty or taper a second time. */
+    int[] apply(int[] frame, Decision decision) {
+        if (!isLit(frame)) return frame;
+        if (decision.resting) return new int[]{0};
+        if (decision.scale >= 0.999) return frame;
+
+        int[] out = frame;
+        // Keep the historical two-stage rounding: quiet-hours dim first, then taper.
+        if (decision.quietScale < 0.999) {
+            out = new int[frame.length];
+            for (int i = 0; i < frame.length; i++) out[i] = Renderer.scale(frame[i], decision.quietScale);
+        }
+        if (decision.taper < 1.0) {
+            int[] tapered = new int[frame.length];
+            for (int i = 0; i < frame.length; i++) tapered[i] = Renderer.scale(out[i], decision.taper);
+            out = tapered;
+        }
+        return out;
+    }
+
+    Decision observe(boolean lit, long now, double dim) {
         if (windowStart == Long.MIN_VALUE || now - windowStart >= dutyWindowMs) {
             windowStart = now;
             litMsInWindow = 0;
             resting = false;
         }
 
-        if (!isLit(frame)) {
+        if (!lit) {
             continuousLitMs = 0;
-            return frame;
+            return new Decision(1.0, resting, 1.0, 1.0);
         }
 
-        if (dim < 0.999) {
-            int[] dimmed = new int[frame.length];
-            for (int i = 0; i < frame.length; i++) dimmed[i] = Renderer.scale(frame[i], dim);
-            frame = dimmed;
-        }
-
-        if (resting) return new int[]{0};
+        double quietScale = applyDim(dim);
+        if (resting) return new Decision(0.0, true, quietScale, 1.0);
 
         litMsInWindow += frameMs;
         continuousLitMs += frameMs;
-
         if (litMsInWindow > dutyWindowMs * maxDuty) {
             resting = true;
-            return new int[]{0};
+            return new Decision(0.0, true, quietScale, 1.0);
         }
 
-        if (continuousLitMs <= taperAfterMs) return frame;
-
-        double over = Math.min(1.0, (continuousLitMs - taperAfterMs) / (double) taperRampMs);
-        double scale = 1.0 - (1.0 - taperFloor) * over;
-        int[] out = new int[frame.length];
-        for (int i = 0; i < frame.length; i++) out[i] = Renderer.scale(frame[i], scale);
-        return out;
+        double taper = 1.0;
+        if (continuousLitMs > taperAfterMs) {
+            double over = Math.min(1.0, (continuousLitMs - taperAfterMs) / (double) taperRampMs);
+            taper = 1.0 - (1.0 - taperFloor) * over;
+        }
+        return new Decision(clamp01(quietScale * taper), false, quietScale, taper);
     }
 
-    boolean isResting() {
-        return resting;
-    }
+    boolean isResting() { return resting; }
 
     int dutyPercent() {
         return (int) (100.0 * litMsInWindow / (dutyWindowMs * maxDuty));
+    }
+
+    private static double clampDim(double dim) {
+        // NaN was treated as no dim by apply's old threshold check; retain that behavior.
+        return Double.isNaN(dim) ? 1.0 : Renderer.clamp01(dim);
+    }
+
+    private static double applyDim(double dim) {
+        // Preserve apply's no-allocation threshold: values at or above .999 were not dimmed.
+        return dim < 0.999 ? clampDim(dim) : 1.0;
+    }
+
+    private static double clamp01(double value) {
+        return value < 0 ? 0 : value > 1 ? 1 : value;
     }
 
     private static boolean isLit(int[] frame) {

--- a/core/src/com/hilight/core/SequenceCompiler.java
+++ b/core/src/com/hilight/core/SequenceCompiler.java
@@ -1,0 +1,384 @@
+package com.hilight.core;
+
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/** Compiles animated renderer patterns into bounded, deterministic hardware tracks. */
+public final class SequenceCompiler {
+
+    private static final int MAX_POINTS_PER_LIGHT = 9;
+    private static final int MAX_TOTAL_POINTS = 72;
+    private static final int MAX_SEGMENTS = MAX_POINTS_PER_LIGHT - 1;
+
+    private SequenceCompiler() {
+        // Utility class.
+    }
+
+    /** The interpolation a hardware consumer should use between track points. */
+    public enum Interpolation {
+        LINEAR,
+        NONE
+    }
+
+    /** A color and the incremental delay at which it is emitted. */
+    public static final class Point {
+        public final long delayMs;
+        public final int color;
+
+        public Point(long delayMs, int color) {
+            this.delayMs = delayMs;
+            this.color = color;
+        }
+
+        public long getDelayMs() {
+            return delayMs;
+        }
+
+        public int getColor() {
+            return color;
+        }
+    }
+
+    /** One light's ordered, incrementally timed points. */
+    public static final class Track {
+        public final List<Point> points;
+        public final List<Long> delaysMs;
+        public final List<Integer> colors;
+
+        private Track(List<Point> points) {
+            this.points = immutable(points);
+            List<Long> delays = new ArrayList<>(points.size());
+            List<Integer> values = new ArrayList<>(points.size());
+            for (Point point : points) {
+                delays.add(point.delayMs);
+                values.add(point.color);
+            }
+            this.delaysMs = Collections.unmodifiableList(delays);
+            this.colors = Collections.unmodifiableList(values);
+        }
+
+        public List<Point> getPoints() {
+            return points;
+        }
+
+        public List<Long> getDelaysMs() {
+            return delaysMs;
+        }
+
+        public List<Integer> getColors() {
+            return colors;
+        }
+
+        public long totalDurationMs() {
+            long total = 0;
+            for (long delay : delaysMs) {
+                if (delay > Long.MAX_VALUE - total) return Long.MAX_VALUE;
+                total += delay;
+            }
+            return total;
+        }
+    }
+
+    /** Immutable compiler result. */
+    public static final class Plan {
+        public final long periodMs;
+        public final Interpolation interpolation;
+        public final List<Track> tracks;
+        public final boolean mayLight;
+
+        private Plan(long periodMs, Interpolation interpolation, List<Track> tracks,
+                     boolean mayLight) {
+            this.periodMs = periodMs;
+            this.interpolation = interpolation;
+            this.tracks = immutable(tracks);
+            this.mayLight = mayLight;
+        }
+
+        public long getPeriodMs() {
+            return periodMs;
+        }
+
+        public Interpolation getInterpolation() {
+            return interpolation;
+        }
+
+        public List<Track> getTracks() {
+            return tracks;
+        }
+
+        public boolean mayLight() {
+            return mayLight;
+        }
+    }
+
+    /**
+     * Builds the preemptive all-black effect used to terminate a colored hardware submission.
+     *
+     * This deliberately is not a renderer/schema plan: every light has the same opaque-black
+     * two-point LINEAR track, and the plan is explicitly marked as unable to light the array.
+     */
+    static Plan blackTerminator(int ledCount, long durationMs) {
+        if (ledCount <= 0 || ledCount > MAX_TOTAL_POINTS / 2 || durationMs <= 0) return null;
+
+        List<Track> tracks = new ArrayList<>(ledCount);
+        for (int light = 0; light < ledCount; light++) {
+            List<Point> points = new ArrayList<>(2);
+            points.add(new Point(0, 0xFF000000));
+            points.add(new Point(durationMs, 0xFF000000));
+            tracks.add(new Track(points));
+        }
+        Plan plan = new Plan(durationMs, Interpolation.LINEAR, tracks, false);
+        // A one-millisecond quantum is the compiler's minimum invariant; the backend applies the
+        // device's actual quantum (33 ms on the certified profile) before submission.
+        return validate(plan, ledCount, 1L) ? plan : null;
+    }
+
+    /** Preserves the original caller API; the default random activation is deterministic. */
+    public static Plan compile(JSONObject cfg, long phaseOriginMs, int ledCount,
+                               long quantumMs, double externalScale) {
+        return compile(cfg, phaseOriginMs, ledCount, quantumMs, externalScale, 0L);
+    }
+
+    /** Compiles with a caller-supplied activation seed for deterministic random patterns. */
+    public static Plan compile(JSONObject cfg, long phaseOriginMs, int ledCount,
+                               long quantumMs, double externalScale, long randomSeed) {
+        if (cfg == null || ledCount <= 0 || ledCount > MAX_TOTAL_POINTS / 2
+                || quantumMs <= 0 || !Double.isFinite(externalScale)
+                || externalScale < 0.0 || externalScale > 1.0) {
+            return null;
+        }
+
+        try {
+            String mode = cfg.optString("mode", cfg.optString("pattern", "off"));
+            if (isContinuous(mode)) {
+                long period = sourcePeriod(cfg);
+                if (period <= 0) return null;
+                long available = period / quantumMs;
+                int segments = (int) Math.min(MAX_SEGMENTS, available);
+                if (segments < 1) return null;
+                int[][] sampled = sampleRenderer(cfg, phaseOriginMs, period, segments,
+                        externalScale, ledCount);
+                return finish(period, Interpolation.LINEAR,
+                        tracks(sampled, boundaries(period, segments)), ledCount, quantumMs);
+            }
+
+            if ("blink".equals(mode)) {
+                long period = sourcePeriod(cfg);
+                if (period <= 0) return null;
+                long first = period / 2;
+                long second = period - first;
+                if (first < quantumMs || second < quantumMs) return null;
+                int[][] sampled = sampleRenderer(cfg, phaseOriginMs, period, 2,
+                        externalScale, ledCount);
+                return finish(period, Interpolation.NONE,
+                        tracks(sampled, new long[]{0, first, period}),
+                        ledCount, quantumMs);
+            }
+
+            if ("chase".equals(mode)) {
+                if (ledCount > MAX_SEGMENTS) return null;
+                long speed = sourcePeriod(cfg);
+                long interval = speed / ledCount;
+                if (interval < 1) interval = 1;
+                if (interval < quantumMs || interval > Long.MAX_VALUE / ledCount) return null;
+                long period = interval * ledCount;
+                int[][] sampled = sampleRenderer(cfg, phaseOriginMs, period, ledCount,
+                        externalScale, ledCount);
+                return finish(period, Interpolation.NONE,
+                        tracks(sampled, intervalBoundaries(interval, ledCount)),
+                        ledCount, quantumMs);
+            }
+
+            if ("custom".equals(mode)) {
+                long rotateMs = cfg.optLong("rotateMs", 0);
+                if (rotateMs <= 50 || ledCount > MAX_SEGMENTS
+                        || rotateMs > Long.MAX_VALUE / ledCount
+                        || rotateMs < quantumMs) return null;
+                long period = rotateMs * ledCount;
+                int[][] sampled = sampleRenderer(cfg, phaseOriginMs, period, ledCount,
+                        externalScale, ledCount);
+                return finish(period, Interpolation.NONE,
+                        tracks(sampled, intervalBoundaries(rotateMs, ledCount)),
+                        ledCount, quantumMs);
+            }
+
+            if ("random".equals(mode)) {
+                long interval = cfg.optLong("randomIntervalMs", 1500);
+                if (interval < 120) interval = 120;
+                if (interval < quantumMs || interval > Long.MAX_VALUE / MAX_SEGMENTS) {
+                    return null;
+                }
+                long period = interval * MAX_SEGMENTS;
+                boolean smooth = cfg.optBoolean("randomSmooth", true);
+                int[][] sampled = randomSamples(cfg, phaseOriginMs, interval, ledCount,
+                        externalScale, randomSeed, smooth);
+                Interpolation interpolation = smooth
+                        ? Interpolation.LINEAR : Interpolation.NONE;
+                return finish(period, interpolation,
+                        tracks(sampled, intervalBoundaries(interval, MAX_SEGMENTS)),
+                        ledCount, quantumMs);
+            }
+
+            // Static and unknown modes are handled by the ordinary output path.
+            return null;
+        } catch (RuntimeException malformedConfig) {
+            // JSONObject values can be malformed at runtime; reject them safely.
+            return null;
+        }
+    }
+
+    private static boolean isContinuous(String mode) {
+        return "breathe".equals(mode) || "pulse".equals(mode) || "wave".equals(mode)
+                || "rainbow".equals(mode) || "comet".equals(mode);
+    }
+
+    private static long sourcePeriod(JSONObject cfg) {
+        return Math.max(60, cfg.optLong("speedMs", 2000));
+    }
+
+    private static int[][] sampleRenderer(JSONObject cfg, long phaseOriginMs, long period,
+                                          int segments, double externalScale, int ledCount) {
+        long[] elapsed = boundaries(period, segments);
+        long base = Math.floorMod(phaseOriginMs, period);
+        int[][] sampled = new int[segments + 1][ledCount];
+        Renderer renderer = new Renderer();
+        for (int sample = 0; sample <= segments; sample++) {
+            long time = addModulo(base, elapsed[sample], period);
+            int[] frame = renderer.frame(cfg, time, ledCount);
+            for (int light = 0; light < ledCount; light++) {
+                sampled[sample][light] = Renderer.scale(frame[light], externalScale);
+            }
+        }
+        return sampled;
+    }
+
+    /** Samples the seeded eight-stage cycle at the requested phase without expanding its shape. */
+    private static int[][] randomSamples(JSONObject cfg, long phaseOriginMs, long interval,
+                                         int ledCount, double externalScale, long seed,
+                                         boolean smooth) {
+        boolean perLed = cfg.optBoolean("randomPerLed", true);
+        float saturation = (float) Renderer.clamp01(
+                cfg.optDouble("randomSaturation", 1.0));
+        double brightness = Renderer.clamp01(cfg.optDouble("brightness", 1.0));
+        int[][] stages = new int[MAX_SEGMENTS][ledCount];
+        for (int stage = 0; stage < MAX_SEGMENTS; stage++) {
+            for (int light = 0; light < ledCount; light++) {
+                long key = seed ^ ((long) stage * 0x9E3779B97F4A7C15L);
+                if (perLed) key ^= (long) light * 0xBF58476D1CE4E5B9L;
+                int hue = (int) Math.floorMod(mix64(key), 360);
+                int color = Renderer.hsv(hue, saturation, 1f);
+                // Scale each deterministic stage once, before any phase interpolation.
+                stages[stage][light] = Renderer.scale(
+                        Renderer.scale(color, brightness), externalScale);
+            }
+        }
+
+        long period = interval * MAX_SEGMENTS;
+        long phase = Math.floorMod(phaseOriginMs, period);
+        int stage = (int) (phase / interval);
+        long remainder = phase % interval;
+        double fraction = remainder / (double) interval;
+        int[][] sampled = new int[MAX_SEGMENTS + 1][ledCount];
+        for (int sample = 0; sample < MAX_SEGMENTS; sample++) {
+            int current = (stage + sample) % MAX_SEGMENTS;
+            int next = (current + 1) % MAX_SEGMENTS;
+            for (int light = 0; light < ledCount; light++) {
+                sampled[sample][light] = smooth
+                        ? Renderer.mix(stages[current][light], stages[next][light], fraction)
+                        : stages[current][light];
+            }
+        }
+        for (int light = 0; light < ledCount; light++) {
+            sampled[MAX_SEGMENTS][light] = sampled[0][light];
+        }
+        return sampled;
+    }
+
+    private static long[] boundaries(long period, int segments) {
+        long[] result = new long[segments + 1];
+        for (int i = 1; i <= segments; i++) {
+            result[i] = boundary(period, segments, i);
+        }
+        return result;
+    }
+
+    private static long[] intervalBoundaries(long interval, int stages) {
+        long[] result = new long[stages + 1];
+        for (int i = 1; i <= stages; i++) {
+            result[i] = interval * i;
+        }
+        return result;
+    }
+
+    private static long boundary(long period, int segments, int index) {
+        long quotient = period / segments;
+        long remainder = period % segments;
+        return quotient * index + (remainder * index) / segments;
+    }
+
+    private static long addModulo(long base, long offset, long period) {
+        if (base <= Long.MAX_VALUE - offset) return base + offset;
+        return base - (period - offset);
+    }
+
+    private static List<Track> tracks(int[][] sampled, long[] elapsed) {
+        List<Track> result = new ArrayList<>(sampled[0].length);
+        for (int light = 0; light < sampled[0].length; light++) {
+            List<Point> points = new ArrayList<>(sampled.length);
+            for (int sample = 0; sample < sampled.length; sample++) {
+                long delay = sample == 0 ? 0 : elapsed[sample] - elapsed[sample - 1];
+                points.add(new Point(delay, sampled[sample][light]));
+            }
+            result.add(new Track(points));
+        }
+        return result;
+    }
+
+    private static Plan finish(long period, Interpolation interpolation, List<Track> tracks,
+                               int ledCount, long quantumMs) {
+        boolean mayLight = false;
+        for (Track track : tracks) {
+            for (int color : track.colors) mayLight |= rgbSum(color) > 12;
+        }
+        Plan plan = new Plan(period, interpolation, tracks, mayLight);
+        return validate(plan, ledCount, quantumMs) ? plan : null;
+    }
+
+    private static boolean validate(Plan plan, int ledCount, long quantumMs) {
+        if (plan == null || plan.periodMs <= 0 || plan.interpolation == null
+                || plan.tracks == null || plan.tracks.size() != ledCount) return false;
+        int total = 0;
+        for (Track track : plan.tracks) {
+            if (track == null || track.points == null || track.points.isEmpty()
+                    || track.points.size() > MAX_POINTS_PER_LIGHT) return false;
+            if (total > MAX_TOTAL_POINTS - track.points.size()) return false;
+            total += track.points.size();
+            if (track.points.get(0).delayMs != 0
+                    || track.totalDurationMs() != plan.periodMs) return false;
+            for (int i = 1; i < track.points.size(); i++) {
+                long delay = track.points.get(i).delayMs;
+                if (delay <= 0 || delay < quantumMs) return false;
+            }
+            if (track.points.get(0).color
+                    != track.points.get(track.points.size() - 1).color) return false;
+        }
+        return total <= MAX_TOTAL_POINTS;
+    }
+
+    private static int rgbSum(int color) {
+        return ((color >> 16) & 0xFF) + ((color >> 8) & 0xFF) + (color & 0xFF);
+    }
+
+    private static long mix64(long value) {
+        value = (value ^ (value >>> 30)) * 0xBF58476D1CE4E5B9L;
+        value = (value ^ (value >>> 27)) * 0x94D049BB133111EBL;
+        return value ^ (value >>> 31);
+    }
+
+    private static <T> List<T> immutable(List<T> source) {
+        return Collections.unmodifiableList(new ArrayList<>(source));
+    }
+}


### PR DESCRIPTION
## Summary
- offload supported HiLight animations to finite `ColorSequence` / `MultiLightEffect` hardware plans
- exact-gate hardware effects to the certified Pixel firmware and 8-light topology, with redundant 9-points-per-light / 72-total validation before Binder
- terminate active color with a small preemptive hardware-black effect, then retain the static black drain and 66 ms software fallback
- cover Breathe, Pulse, Wave, Rainbow, Comet, Blink, Chase, rotating Custom, and deterministic Random hardware cycles

## Why
At a 33 ms software cadence, a full eight-light static batch could outrun the sequential HAL and closing immediately could truncate black cleanup. Large hardware plans also returned successfully from Binder and then asynchronously aborted the vendor service's fixed FlatBuffer allocator.

The bounded representation follows first-party device evidence: a captured Google/Gemini animation used 9 points on each of 8 lights (72 total) through the same framework API. Hardware submission is conservatively enabled only for the exact certified build fingerprint/topology; everything else retains the software path.

## Safety
- validates every plan again immediately before `setLightEffect`
- never sends more than 9 points per light or 72 total
- uses finite iterations and prevents scale-only replacement when a complete cycle cannot fit before termination
- preempts active color with an 8x2 opaque-black effect, waits for it, forces static black, drains, then closes
- preserves the 66 ms fallback, duty/rest/taper controls, and data/schema compatibility

## Testing
- `./gradlew test assemble` — 62 tests passed on this independent `origin/main`-based branch
- `git diff --check`
- debug and release `com.hilight.core` class files are byte-for-byte identical to the device-certified combined build
- Pixel device acceptance: smooth 4 s Rainbow, original 10.317 s / 628 ms red Breathe, and real Gmail notification
- vendor lights-service PID remained stable; no new allocator crash/tombstone; final lights black with no active session
