### PR TITLE
Stop the rule picker hiding apps that only notify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to HiLight Studio are documented here.
 
 ## [Unreleased]
 
+- Fixed the rule picker leaving out apps that have no launcher activity. Android's own permission
+  prompts are remembered as chats but could never be given a rule, because the picker listed only
+  apps that can be opened. Any package HiLight has already seen notify is now offered alongside
+  them.
+
 ## [1.0.8-experimental] - 2026-08-25
 
 - Released the light session whenever a rendered frame is dark, so an idle or temporarily dark

--- a/app/src/main/java/com/hilight/studio/AppRulesScreen.kt
+++ b/app/src/main/java/com/hilight/studio/AppRulesScreen.kt
@@ -155,6 +155,7 @@ fun AppRulesScreen(store: Store) {
 
     if (picking) {
         AppPickerDialog(
+            alsoOffer = conversations.mapTo(mutableSetOf()) { it.pkg },
             onDismiss = { picking = false },
             onPick = { app ->
                 picking = false
@@ -421,18 +422,38 @@ private fun RuleCard(
 }
 
 @Composable
-fun AppPickerDialog(onDismiss: () -> Unit, onPick: (InstalledApp) -> Unit) {
+fun AppPickerDialog(
+    onDismiss: () -> Unit,
+    onPick: (InstalledApp) -> Unit,
+    /**
+     * Packages to offer beyond the ones carrying a launcher activity.
+     *
+     * A launcher query answers "what can this person open", which is not the question this screen
+     * asks. `android` posts the permission prompts, and an app whose launcher has been hidden still
+     * reaches the shade — both are already remembered as chats, and neither can be picked here, so
+     * the screen refuses a rule for a notification HiLight has demonstrably seen.
+     */
+    alsoOffer: Set<String> = emptySet(),
+) {
     val ctx = LocalContext.current
     var query by remember { mutableStateOf("") }
-    val apps by produceState(initialValue = emptyList<InstalledApp>()) {
+    val apps by produceState(initialValue = emptyList<InstalledApp>(), alsoOffer) {
         value = withContext(Dispatchers.IO) {
             val pm = ctx.packageManager
             val launchable = Intent(Intent.ACTION_MAIN).addCategory(Intent.CATEGORY_LAUNCHER)
-            pm.queryIntentActivities(launchable, 0)
+            val launcherApps = pm.queryIntentActivities(launchable, 0)
                 .mapNotNull { ri ->
                     val ai = ri.activityInfo?.applicationInfo ?: return@mapNotNull null
                     InstalledApp(ai.packageName, pm.getApplicationLabel(ai).toString(), ai)
                 }
+            val launcherPkgs = launcherApps.mapTo(mutableSetOf()) { it.pkg }
+            val seenOnly = (alsoOffer - launcherPkgs).mapNotNull { pkg ->
+                runCatching {
+                    val ai = pm.getApplicationInfo(pkg, 0)
+                    InstalledApp(pkg, pm.getApplicationLabel(ai).toString(), ai)
+                }.getOrNull()
+            }
+            (launcherApps + seenOnly)
                 .distinctBy { it.pkg }
                 .sortedBy { it.label.lowercase() }
         }


### PR DESCRIPTION
The rule picker lists only apps with a launcher activity, so a package that
notifies but cannot be opened is invisible to it. Android's own permission
prompts are the case most people will have: HiLight already remembers them
as chats, and the Apps screen will not let a rule be written for them.

This offers packages already remembered as chats alongside the launchable
apps. No new data is collected and no new permission is needed —
QUERY_ALL_PACKAGES is already held, and the added entries disappear again
when "Forget remembered chats" is used.

The privacy-rule picker shares the dialog and is unchanged; the packages are
passed in only where notification rules are created.

Checks: `./gradlew :app:testDebugUnitTest :app:build :app:lint` — 90 tests
pass, and lint reports the same 42 warnings as before with none in the
changed file.

Tested on a Pixel 11 Pro, Android 17 (SDK 37), ADB transport: created a rule
for a package with no launcher activity and confirmed it matched and fired.

<img width="459" height="1024" alt="image" src="https://github.com/user-attachments/assets/e0153b36-81af-4442-990b-b16a0956c716" />

