### PR TITLE
add typed entry to time sliders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to HiLight Studio are documented here.
 
 ## [Unreleased]
 
+- Added typed entry on time sliders: tapping the value badge opens a dialog to type the time in
+  seconds, for values the hundredth-stepped drag is too coarse to land on. Typed values are clamped
+  to the slider's range, so the long-duration safety gates still apply.
+
 ## [1.0.8-experimental] - 2026-08-25
 
 - Released the light session whenever a rendered frame is dark, so an idle or temporarily dark

--- a/app/src/main/java/com/hilight/studio/AmbientScreen.kt
+++ b/app/src/main/java/com/hilight/studio/AmbientScreen.kt
@@ -94,6 +94,7 @@ fun AmbientScreen(store: Store) {
                         ambient.randomIntervalMs.toFloat(),
                         150f..8000f,
                         { store.setAmbient(ambient.copy(randomIntervalMs = it.toInt())) },
+                        typeInSeconds = true,
                     ) {
                         // shown to a tenth of a second, so dragging does not spray digits
                         val tenths = (it / 100).toInt() / 10f
@@ -148,6 +149,7 @@ fun AmbientScreen(store: Store) {
                         ambient.rotateMs.toFloat(),
                         0f..2000f,
                         { store.setAmbient(ambient.copy(rotateMs = it.toInt())) },
+                        typeInSeconds = true,
                     ) {
                         if (it < 50) stringResource(R.string.style_rotate_off)
                         else stringResource(R.string.duration_ms, it.toInt())
@@ -210,6 +212,7 @@ fun AmbientScreen(store: Store) {
                             ambient.speedMs.toFloat(),
                             150f..8000f,
                             { store.setAmbient(ambient.copy(speedMs = it.toInt())) },
+                            typeInSeconds = true,
                         ) { formatDuration(it.toInt()) }
                         pattern.cycleMeaningRes?.let { Caption(stringResource(it)) }
                         Caption(stringResource(R.string.style_shorter_is_faster))

--- a/app/src/main/java/com/hilight/studio/AppRulesScreen.kt
+++ b/app/src/main/java/com/hilight/studio/AppRulesScreen.kt
@@ -674,6 +674,7 @@ private fun RuleEditorDialog(
                         r.speedMs.toFloat(),
                         150f..5000f,
                         { r = r.copy(speedMs = it.toInt()) },
+                        typeInSeconds = true,
                     ) { formatDuration(it.toInt()) }
                     r.pattern.cycleMeaningRes?.let { Caption(stringResource(it)) }
                 }

--- a/app/src/main/java/com/hilight/studio/PixelUi.kt
+++ b/app/src/main/java/com/hilight/studio/PixelUi.kt
@@ -24,7 +24,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -52,6 +54,7 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -276,10 +279,14 @@ fun PixelSlider(
     value: Float,
     range: ClosedFloatingPointRange<Float>,
     onChange: (Float) -> Unit,
+    // Opt-in for ms-valued sliders: tapping the badge opens a dialog to type the time in seconds,
+    // since the slider's hundredth-steps are hard to land exactly by drag.
+    typeInSeconds: Boolean = false,
     // Composable because the value badge often shows a duration, and a duration's units come from
     // resources now that they have to be translated.
     format: @Composable (Float) -> String = { "%.0f".format(it) },
 ) {
+    var typing by remember { mutableStateOf(false) }
     Column {
         Row(
             Modifier.fillMaxWidth(),
@@ -289,7 +296,9 @@ fun PixelSlider(
             Text(label, style = MaterialTheme.typography.bodyLarge)
             Box(
                 Modifier
-                    .background(MaterialTheme.colorScheme.secondaryContainer, CircleShape)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.secondaryContainer)
+                    .then(if (typeInSeconds) Modifier.clickable { typing = true } else Modifier)
                     .padding(horizontal = 10.dp, vertical = 3.dp)
             ) {
                 Text(
@@ -307,6 +316,43 @@ fun PixelSlider(
                 activeTrackColor = MaterialTheme.colorScheme.primary,
                 inactiveTrackColor = MaterialTheme.colorScheme.surfaceContainerHighest,
             ),
+        )
+    }
+    if (typing) {
+        // Prefilled in seconds, trailing zeros trimmed; the separator may be a comma in locales
+        // that write one, so parsing accepts both.
+        var text by remember {
+            mutableStateOf("%.2f".format(value / 1000f).trimEnd('0').trimEnd('.', ','))
+        }
+        val typedMs = text.trim().replace(',', '.').toFloatOrNull()?.times(1000f)
+        AlertDialog(
+            onDismissRequest = { typing = false },
+            shape = MaterialTheme.shapes.extraLarge,
+            title = { Text(label) },
+            text = {
+                OutlinedTextField(
+                    value = text,
+                    onValueChange = { text = it },
+                    singleLine = true,
+                    label = { Text(stringResource(R.string.duration_seconds_field)) },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    enabled = typedMs != null,
+                    onClick = {
+                        typing = false
+                        // Clamped to the slider's own range, so typing cannot pass a safety gate.
+                        if (typedMs != null) onChange(typedMs.coerceIn(range))
+                    },
+                ) { ButtonLabel(stringResource(R.string.common_save)) }
+            },
+            dismissButton = {
+                TextButton(onClick = { typing = false }) {
+                    ButtonLabel(stringResource(R.string.common_cancel))
+                }
+            },
         )
     }
 }
@@ -419,6 +465,7 @@ fun GatedDurationSlider(
         value = valueMs.toFloat(),
         range = minMs.toFloat()..(if (unlocked) extendedMaxMs else safeMaxMs).toFloat(),
         onChange = { onChange(it.toInt()) },
+        typeInSeconds = true,
     ) { formatDuration(it.toInt()) }
 
     ToggleRow(unlockLabel, unlocked) { wanted ->

--- a/app/src/main/java/com/hilight/studio/PrivacyRulesSection.kt
+++ b/app/src/main/java/com/hilight/studio/PrivacyRulesSection.kt
@@ -252,6 +252,7 @@ fun PrivacyRuleEditorDialog(
                     value = edited.cooldownMs.toFloat(),
                     range = PrivacyRule.MIN_PHASE_MS.toFloat()..PrivacyRule.MAX_PHASE_MS.toFloat(),
                     onChange = { edited = edited.copy(cooldownMs = it.toInt()) },
+                    typeInSeconds = true,
                 ) { formatDuration(it.toInt()) }
                 Caption(
                     if (edited.cooldownMs < 10_000)
@@ -264,6 +265,7 @@ fun PrivacyRuleEditorDialog(
                         stringResource(R.string.rules_time_per_cycle),
                         edited.speedMs.toFloat(), 150f..5000f,
                         { edited = edited.copy(speedMs = it.toInt()) },
+                        typeInSeconds = true,
                     ) { formatDuration(it.toInt()) }
                 }
                 PixelSlider(

--- a/app/src/main/res/values-ja/strings_common.xml
+++ b/app/src/main/res/values-ja/strings_common.xml
@@ -96,6 +96,8 @@
     <string name="duration_minutes">%1$d分</string>
     <!-- "%1$dm %2$ds" -->
     <string name="duration_minutes_seconds">%1$d分%2$d秒</string>
+    <!-- "Seconds" — field label in the dialog for typing a duration directly -->
+    <string name="duration_seconds_field">秒</string>
 
     <!-- Buttons and labels used on more than one screen -->
     <!-- "Cancel" -->

--- a/app/src/main/res/values/strings_common.xml
+++ b/app/src/main/res/values/strings_common.xml
@@ -63,6 +63,8 @@
     <string name="duration_seconds">%1$ds</string>
     <string name="duration_minutes">%1$dm</string>
     <string name="duration_minutes_seconds">%1$dm %2$ds</string>
+    <!-- Field label in the dialog for typing a duration directly -->
+    <string name="duration_seconds_field">Seconds</string>
 
     <!-- Buttons and labels used on more than one screen -->
     <string name="common_cancel">Cancel</string>


### PR DESCRIPTION
## Summary

Added tap-to-type on all time sliders. I found it difficult to get the precise values that I wanted with the sliders alone so I added this feature. It is not applied to the percentage sliders, since those use whole numbers. Typed values are clamped to the slider's own range, so the long-duration safety gate can't be bypassed by typing huge values.

## Verification

**Tested on Pixel 11 Pro running Android 17**
- [x] `./gradlew :app:testDebugUnitTest :app:build :app:lint`
- [x] Tested on a supported Pixel device, if renderer, transport, or timing changed
- [x] No notification contents or other personal data are included

## Screenshots

*Before tapping*

<img height="714" alt="Before tap image" src="https://github.com/user-attachments/assets/8cc7671c-a057-4e16-abf5-fb697751cfa4" />  

*Dialog opens pre-filled*  

<img height="714" alt="Dialog opens pre-filled" src="https://github.com/user-attachments/assets/e505311c-f46d-40fd-a7cb-2d10085657fd" />  

*Typing dialog*

<img height="714" alt="Typing 3.37 on decimal keyboard" src="https://github.com/user-attachments/assets/ded4aaf9-0783-4b36-aed3-1ecbec74f76b" />  

*Saved, rounding to the nearest tenth in the UI*  

<img height="714" alt="Saved as 3.4s in the UI" src="https://github.com/user-attachments/assets/61395c89-766c-4566-b3f4-67963c926c3c" />  

*Re-opened, exact 3.37 value kept*  

<img height="714" alt="Menu re-opened, exact 3.37 value kept" src="https://github.com/user-attachments/assets/ac99e1b4-0933-4984-b5ce-3584a61d4a06" />  

*After typing 999, is properly clamped at 8s*  

<img height="714" alt="After typing 999, is properly clamped at 8s" src="https://github.com/user-attachments/assets/f9c27e1d-3ec4-4b75-9174-cb6f54a8cfae" />  
