### PR TITLE
feat: persistent notification alerts

### DIFF
--- a/app/src/main/java/com/hilight/studio/NotificationTrigger.kt
+++ b/app/src/main/java/com/hilight/studio/NotificationTrigger.kt
@@ -104,12 +104,13 @@ class NotificationTrigger : NotificationListenerService() {
             ?: if (rule.isCatchAll) MatchStrength.CATCH_ALL else MatchStrength.APP
         val scope = if (rule.isConversationRule) "chat" else "app"
         Log.i(TAG, "alert for ${info.pkg} rule=$scope match=$how pattern=${rule.pattern.key}")
-        store.fireAlert(rule)
+        val notifKey = info.notifKey.ifEmpty { sbn.key }
+        store.fireAlert(rule, notifKey)
         store.noteRuleFired(rule, info)
     }
 
     /**
-     * Forgets a dismissed notification's stamp.
+     * Forgets a dismissed notification's stamp and clears its active alert if any.
      *
      * The key is derived exactly the way it was on the way in, so the two sides cannot drift apart if
      * the peek ever stops using the framework's own key. Without this a chat that is dismissed and
@@ -118,8 +119,11 @@ class NotificationTrigger : NotificationListenerService() {
      */
     override fun onNotificationRemoved(sbn: StatusBarNotification) {
         runCatching {
-            val key = NotificationPeek.read(sbn).notifKey
-            if (key.isNotEmpty()) synchronized(handled) { handled.remove(key) }
+            val key = NotificationPeek.read(sbn).notifKey.ifEmpty { sbn.key }
+            if (key.isNotEmpty()) {
+                synchronized(handled) { handled.remove(key) }
+                store.dismissNotificationAlert(key)
+            }
         }.onFailure { Log.w(TAG, "could not handle removal", it) }
     }
 
@@ -130,6 +134,7 @@ class NotificationTrigger : NotificationListenerService() {
      */
     override fun onListenerDisconnected() {
         synchronized(handled) { handled.clear() }
+        store.clearActiveNotifications()
     }
 
     /**

--- a/app/src/main/java/com/hilight/studio/SetupScreen.kt
+++ b/app/src/main/java/com/hilight/studio/SetupScreen.kt
@@ -104,6 +104,8 @@ fun SetupScreen(store: Store) {
     val quietDim by store.quietDim.collectAsStateWithLifecycle()
     val quietDimPct by store.quietDimPct.collectAsStateWithLifecycle()
     val screenOffOnly by store.screenOffOnly.collectAsStateWithLifecycle()
+    val keepNotifUntilDismissed by store.keepNotifUntilDismissed.collectAsStateWithLifecycle()
+    val notifAlternateIntervalMs by store.notifAlternateIntervalMs.collectAsStateWithLifecycle()
 
     var notifAccess by remember { mutableStateOf(hasNotificationAccess(ctx)) }
     var usageAccess by remember { mutableStateOf(ForegroundWatcher.hasUsageAccess(ctx)) }
@@ -291,6 +293,22 @@ fun SetupScreen(store: Store) {
         Caption(stringResource(R.string.setup_inspector_body))
         TextButton(onClick = { inspecting = true }) {
             ButtonLabel(stringResource(R.string.setup_inspector_button))
+        }
+        ToggleRow(
+            stringResource(R.string.setup_notif_until_dismissed),
+            keepNotifUntilDismissed,
+        ) {
+            store.setKeepNotifUntilDismissed(it)
+        }
+        Caption(stringResource(R.string.setup_notif_until_dismissed_hint))
+        if (keepNotifUntilDismissed) {
+            PixelSlider(
+                stringResource(R.string.setup_notif_alternate_interval),
+                notifAlternateIntervalMs.toFloat(),
+                2000f..10000f,
+                { store.setNotifAlternateIntervalMs(it.toInt()) },
+            ) { formatDuration(it.toInt()) }
+            Caption(stringResource(R.string.setup_notif_alternate_hint))
         }
         // The chat picker's convenience comes from a list of real contact names held on the device,
         // so there has to be a way to be rid of it without uninstalling. Rules keep their own copy of

--- a/app/src/main/java/com/hilight/studio/Store.kt
+++ b/app/src/main/java/com/hilight/studio/Store.kt
@@ -1374,107 +1374,12 @@ class Store private constructor(private val app: Context) {
      * Clears all active notification alerts.
      */
     fun clearActiveNotifications() {
-            main.post { runCatching { clearActiveNotifications() }.onFailure { Log.w(TAG, "clear notifications failed", it) } }
-        }
-        activeNotifAlerts.clear()
-        stopNotifAlternation()
-        if (!alertIsPreview && _keepNotifUntilDismissed.value) {
-            releaseAlert()
-        }
-    }
-
-    private fun stopNotifAlternation() {
-        notifAlternationTask?.let { main.removeCallbacks(it) }
-        notifAlternationTask = null
-    }
-
-    private fun cycleActiveNotificationAlert() {
-        stopNotifAlternation()
-        if (!_enabled.value || activeNotifAlerts.isEmpty()) {
-            if (!alertIsPreview) releaseAlert()
-            return
-        }
-        if (alertIsPreview) return
-        if (guardState().alertSuppression() != null) {
-            scheduleNextNotifCycle()
-            return
-        }
-
-        val entries = activeNotifAlerts.values.toList()
-        if (entries.isEmpty()) {
-            releaseAlert()
-            return
-        }
-
-        activeNotifIndex = activeNotifIndex % entries.size
-        val current = entries[activeNotifIndex]
-        val interval = _notifAlternateIntervalMs.value
-
-        val pm = app.getSystemService(android.os.PowerManager::class.java)
-        val screenOn = pm?.isInteractive ?: true
-        if (current.rule.onlyWhenScreenOff && screenOn) {
-            scheduleNextNotifCycle()
-            return
-        }
-
-        activeAlert = Bridge.alertJson(
-            id = Bridge.nextAlertId(),
-            pattern = current.rule.pattern,
-            color = current.color,
-            durationMs = interval,
-            speedMs = current.rule.speedMs,
-            brightness = current.rule.brightness,
-            source = AlertSource.NOTIFICATION,
-        )
-        send(_enabled.value, activeAlert, arm = false)
-        scheduleNextNotifCycle()
-    }
-
-    private fun scheduleNextNotifCycle() {
-        stopNotifAlternation()
-        val interval = _notifAlternateIntervalMs.value.toLong()
-        val r = Runnable {
-            if (_keepNotifUntilDismissed.value && activeNotifAlerts.isNotEmpty()) {
-                val count = activeNotifAlerts.size
-                if (count > 1) {
-                    activeNotifIndex = (activeNotifIndex + 1) % count
-                }
-                cycleActiveNotificationAlert()
-            }
-        }
-        notifAlternationTask = r
-        main.postDelayed(r, interval)
-    }
-
-    /**
-     * Removes an active notification alert when the notification is dismissed from the shade.
-     */
-    fun dismissNotificationAlert(notifKey: String) {
         if (Looper.myLooper() != main.looper) {
             main.post {
-                runCatching { dismissNotificationAlert(notifKey) }
-                    .onFailure { Log.w(TAG, "dismiss alert failed", it) }
+                runCatching { clearActiveNotifications() }
+                    .onFailure { Log.w(TAG, "clear notifications failed", it) }
             }
             return
-        }
-        if (activeNotifAlerts.remove(notifKey) != null) {
-            if (activeNotifAlerts.isEmpty()) {
-                stopNotifAlternation()
-                if (!alertIsPreview) releaseAlert()
-            } else {
-                activeNotifIndex = activeNotifIndex % activeNotifAlerts.size
-                if (_keepNotifUntilDismissed.value && !alertIsPreview) {
-                    cycleActiveNotificationAlert()
-                }
-            }
-        }
-    }
-
-    /**
-     * Clears all active notification alerts.
-     */
-    fun clearActiveNotifications() {
-            main.post { runCatching { clearActiveNotifications() }.onFailure { Log.w(TAG, "clear notifications failed", it) } }
         }
         activeNotifAlerts.clear()
         stopNotifAlternation()

--- a/app/src/main/java/com/hilight/studio/Store.kt
+++ b/app/src/main/java/com/hilight/studio/Store.kt
@@ -331,7 +331,7 @@ class Store private constructor(private val app: Context) {
     val keepNotifUntilDismissed: StateFlow<Boolean> = _keepNotifUntilDismissed.asStateFlow()
 
     private val _notifAlternateIntervalMs =
-        MutableStateFlow(prefs.getInt("notifAlternateIntervalMs", 4000))
+        MutableStateFlow(prefs.getInt("notifAlternateIntervalMs", 4000).coerceIn(2000, 10000))
     val notifAlternateIntervalMs: StateFlow<Int> = _notifAlternateIntervalMs.asStateFlow()
 
     private val _suppression = MutableStateFlow<Suppression?>(null)
@@ -442,7 +442,6 @@ class Store private constructor(private val app: Context) {
         val notifKey: String,
         val rule: AppRule,
         val color: Int,
-        val postTime: Long = 0L,
     )
     private var handoffAwaitingRetry = false
     private var fatalTerminationInFlight = false
@@ -1312,9 +1311,7 @@ class Store private constructor(private val app: Context) {
      * Clears all active notification alerts.
      */
     fun clearActiveNotifications() {
-        if (Looper.myLooper() != main.looper) {
-            main.post { runCatching { clearActiveNotifications() } }
-            return
+            main.post { runCatching { clearActiveNotifications() }.onFailure { Log.w(TAG, "clear notifications failed", it) } }
         }
         activeNotifAlerts.clear()
         stopNotifAlternation()

--- a/app/src/main/java/com/hilight/studio/Store.kt
+++ b/app/src/main/java/com/hilight/studio/Store.kt
@@ -81,6 +81,14 @@ class Store private constructor(private val app: Context) {
     private val _respectDnd = MutableStateFlow(prefs.getBoolean("respectDnd", true))
     val respectDnd: StateFlow<Boolean> = _respectDnd.asStateFlow()
 
+    private val _keepNotifUntilDismissed =
+        MutableStateFlow(prefs.getBoolean("keepNotifUntilDismissed", false))
+    val keepNotifUntilDismissed: StateFlow<Boolean> = _keepNotifUntilDismissed.asStateFlow()
+
+    private val _notifAlternateIntervalMs =
+        MutableStateFlow(prefs.getInt("notifAlternateIntervalMs", 4000))
+    val notifAlternateIntervalMs: StateFlow<Int> = _notifAlternateIntervalMs.asStateFlow()
+
     private val _suppression = MutableStateFlow<Suppression?>(null)
     val suppression: StateFlow<Suppression?> = _suppression.asStateFlow()
 
@@ -168,12 +176,22 @@ class Store private constructor(private val app: Context) {
      */
     private var activeAlert: JSONObject? = null
     private var alertExpiry: Runnable? = null
+    private val activeNotifAlerts = LinkedHashMap<String, ActiveNotificationAlert>()
+    private var activeNotifIndex = 0
+    private var notifAlternationTask: Runnable? = null
     private var stateRevision = SystemClock.elapsedRealtime()
     private var rootTransition = false
     private var drivingTransport: Transport? = null
     private var handoffTarget: Transport? = null
     private var handoffGeneration = 0L
     private var pendingHandoff: PendingOutput? = null
+
+    data class ActiveNotificationAlert(
+        val notifKey: String,
+        val rule: AppRule,
+        val color: Int,
+        val postTime: Long = 0L,
+    )
 
     private data class PendingOutput(val enabled: Boolean, val alert: JSONObject?, val arm: Boolean)
 
@@ -193,7 +211,12 @@ class Store private constructor(private val app: Context) {
             object : android.content.BroadcastReceiver() {
                 override fun onReceive(c: Context?, i: Intent?) {
                     when (i?.action) {
-                        Intent.ACTION_SCREEN_OFF -> refreshSuppression(armOnRelease = true)
+                        Intent.ACTION_SCREEN_OFF -> {
+                            refreshSuppression(armOnRelease = true)
+                            if (_keepNotifUntilDismissed.value && activeNotifAlerts.isNotEmpty()) {
+                                cycleActiveNotificationAlert()
+                            }
+                        }
                         Intent.ACTION_SCREEN_ON, Intent.ACTION_USER_PRESENT -> {
                             // The screen coming on, or the phone being unlocked, means the
                             // notification has been seen — a rule's colour has no one left to tell,
@@ -275,10 +298,33 @@ class Store private constructor(private val app: Context) {
     fun setEnabled(v: Boolean) {
         _enabled.value = v
         prefs.edit().putBoolean("enabled", v).apply()
+        if (!v) {
+            stopNotifAlternation()
+            activeNotifAlerts.clear()
+        }
         syncForegroundWatcher()
         if (v && root.state.value == RootBackend.State.AVAILABLE) beginRootStart()
         else pushCurrent()
         HiLightTile.refresh(app)
+    }
+
+    fun setKeepNotifUntilDismissed(v: Boolean) {
+        _keepNotifUntilDismissed.value = v
+        prefs.edit().putBoolean("keepNotifUntilDismissed", v).apply()
+        if (!v) {
+            stopNotifAlternation()
+            activeNotifAlerts.clear()
+            if (!alertIsPreview) releaseAlert()
+        }
+    }
+
+    fun setNotifAlternateIntervalMs(v: Int) {
+        val clamped = v.coerceIn(2000, 10000)
+        _notifAlternateIntervalMs.value = clamped
+        prefs.edit().putInt("notifAlternateIntervalMs", clamped).apply()
+        if (_keepNotifUntilDismissed.value && activeNotifAlerts.isNotEmpty() && !alertIsPreview) {
+            cycleActiveNotificationAlert()
+        }
     }
 
     /** Restores or stops the service to match saved rules and the master switch. */
@@ -798,8 +844,8 @@ class Store private constructor(private val app: Context) {
     fun pushCurrent(arm: Boolean = true) =
         send(_enabled.value, activeAlert ?: foregroundOverride?.second, arm)
 
-    /** Fires a one-shot alert, then falls back to the override/ambient layer. */
-    fun fireAlert(rule: AppRule) {
+    /** Fires an alert for a notification rule. */
+    fun fireAlert(rule: AppRule, notifKey: String? = null) {
         // The notification listener calls this from its own thread, while the alert slot below, its
         // expiry callback and every other push are main-thread state. Hopping once here keeps the top
         // layer single-threaded instead of trusting two threads not to interleave over it — an alert
@@ -807,16 +853,26 @@ class Store private constructor(private val app: Context) {
         // stuck on. The bridge write this ends in already happens on main for every slider the user
         // moves, so it is not a new cost.
         if (Looper.myLooper() != main.looper) {
-            main.post { runCatching { fireAlert(rule) }.onFailure { Log.w(TAG, "alert failed", it) } }
+            main.post { runCatching { fireAlert(rule, notifKey) }.onFailure { Log.w(TAG, "alert failed", it) } }
             return
         }
         if (!_enabled.value) return
+        val color = if (rule.randomColor) randomColor() else rule.color
+
+        if (_keepNotifUntilDismissed.value && !notifKey.isNullOrEmpty()) {
+            activeNotifAlerts[notifKey] = ActiveNotificationAlert(notifKey, rule, color)
+            val keys = activeNotifAlerts.keys.toList()
+            val newIdx = keys.indexOf(notifKey)
+            if (newIdx >= 0) activeNotifIndex = newIdx
+            cycleActiveNotificationAlert()
+            return
+        }
+
         // Quiet hours and the battery rules silence a flash; the global "only while the screen is
         // off" switch does not. That switch governs the always-on look, and letting it block here
         // killed every per-app colour for as long as the screen was on. Per-rule
         // AppRule.onlyWhenScreenOff is how a rule asks to flash only on a dark screen.
         if (guardState().alertSuppression() != null) return
-        val color = if (rule.randomColor) randomColor() else rule.color
         holdAlert(
             alert = Bridge.alertJson(
                 id = Bridge.nextAlertId(),
@@ -831,6 +887,108 @@ class Store private constructor(private val app: Context) {
             arm = false,               // a notification must not extend the ambient window
             preview = null,
         )
+    }
+
+    /**
+     * Removes an active notification alert when the notification is dismissed from the shade.
+     */
+    fun dismissNotificationAlert(notifKey: String) {
+        if (Looper.myLooper() != main.looper) {
+            main.post {
+                runCatching { dismissNotificationAlert(notifKey) }
+                    .onFailure { Log.w(TAG, "dismiss alert failed", it) }
+            }
+            return
+        }
+        if (activeNotifAlerts.remove(notifKey) != null) {
+            if (activeNotifAlerts.isEmpty()) {
+                stopNotifAlternation()
+                if (!alertIsPreview) releaseAlert()
+            } else {
+                activeNotifIndex = activeNotifIndex % activeNotifAlerts.size
+                if (_keepNotifUntilDismissed.value && !alertIsPreview) {
+                    cycleActiveNotificationAlert()
+                }
+            }
+        }
+    }
+
+    /**
+     * Clears all active notification alerts.
+     */
+    fun clearActiveNotifications() {
+        if (Looper.myLooper() != main.looper) {
+            main.post { runCatching { clearActiveNotifications() } }
+            return
+        }
+        activeNotifAlerts.clear()
+        stopNotifAlternation()
+        if (!alertIsPreview && _keepNotifUntilDismissed.value) {
+            releaseAlert()
+        }
+    }
+
+    private fun stopNotifAlternation() {
+        notifAlternationTask?.let { main.removeCallbacks(it) }
+        notifAlternationTask = null
+    }
+
+    private fun cycleActiveNotificationAlert() {
+        stopNotifAlternation()
+        if (!_enabled.value || activeNotifAlerts.isEmpty()) {
+            if (!alertIsPreview) releaseAlert()
+            return
+        }
+        if (alertIsPreview) return
+        if (guardState().alertSuppression() != null) {
+            scheduleNextNotifCycle()
+            return
+        }
+
+        val entries = activeNotifAlerts.values.toList()
+        if (entries.isEmpty()) {
+            releaseAlert()
+            return
+        }
+
+        activeNotifIndex = activeNotifIndex % entries.size
+        val current = entries[activeNotifIndex]
+        val interval = _notifAlternateIntervalMs.value
+
+        val pm = app.getSystemService(android.os.PowerManager::class.java)
+        val screenOn = pm?.isInteractive ?: true
+        if (current.rule.onlyWhenScreenOff && screenOn) {
+            scheduleNextNotifCycle()
+            return
+        }
+
+        activeAlert = Bridge.alertJson(
+            id = Bridge.nextAlertId(),
+            pattern = current.rule.pattern,
+            color = current.color,
+            durationMs = interval,
+            speedMs = current.rule.speedMs,
+            brightness = current.rule.brightness,
+            source = AlertSource.NOTIFICATION,
+        )
+        send(_enabled.value, activeAlert, arm = false)
+        scheduleNextNotifCycle()
+    }
+
+    private fun scheduleNextNotifCycle() {
+        stopNotifAlternation()
+        val interval = _notifAlternateIntervalMs.value.toLong()
+        val r = Runnable {
+            if (_keepNotifUntilDismissed.value && activeNotifAlerts.isNotEmpty()) {
+                val count = activeNotifAlerts.size
+                if (count > 1) {
+                    activeNotifIndex = (activeNotifIndex + 1) % count
+                }
+                cycleActiveNotificationAlert()
+            }
+        }
+        notifAlternationTask = r
+        main.postDelayed(r, interval)
     }
 
     /**
@@ -863,7 +1021,11 @@ class Store private constructor(private val app: Context) {
         activeAlert = null
         alertIsPreview = false
         _previewLook.value = null
-        pushCurrent(arm = false)       // handing the layer back must not extend the ambient window
+        if (_keepNotifUntilDismissed.value && activeNotifAlerts.isNotEmpty()) {
+            cycleActiveNotificationAlert()
+        } else {
+            pushCurrent(arm = false)       // handing the layer back must not extend the ambient window
+        }
     }
 
     /**
@@ -873,10 +1035,16 @@ class Store private constructor(private val app: Context) {
      * has been there is nothing to keep lit. No-op when no alert is in flight.
      */
     fun cancelAlert() {
-        if (activeAlert == null) return
+        if (activeAlert == null && notifAlternationTask == null) return
         alertExpiry?.let { main.removeCallbacks(it) }
         alertExpiry = null
-        releaseAlert()
+        if (!_keepNotifUntilDismissed.value) {
+            releaseAlert()
+        } else {
+            stopNotifAlternation()
+            activeAlert = null
+            pushCurrent(arm = false)
+        }
     }
 
     /** Holds a look for as long as [pkg] is in the foreground. */

--- a/app/src/main/res/values-ja/strings_setup.xml
+++ b/app/src/main/res/values-ja/strings_setup.xml
@@ -155,6 +155,14 @@
     <string name="setup_inspector_body">HiLight が各通知から読み取った内容を表示します。メッセージ本文は含みません。</string>
     <!-- "Notification inspector" -->
     <string name="setup_inspector_button">通知インスペクター</string>
+    <!-- "Stay on until dismissed" -->
+    <string name="setup_notif_until_dismissed">通知が消えるまで点灯</string>
+    <!-- "Keeps the notification pattern playing until the notification is dismissed from the shade instead of turning off after a set duration." -->
+    <string name="setup_notif_until_dismissed_hint">一定時間で消灯する代わりに、通知が消去されるまで点灯パターンを継続します。</string>
+    <!-- "Alternate pattern every" -->
+    <string name="setup_notif_alternate_interval">切り替え間隔</string>
+    <!-- "When multiple notifications are present, alternates between each notification's pattern and colour." -->
+    <string name="setup_notif_alternate_hint">複数の通知がある場合、それぞれの通知のパターンと色を交互に切り替えます。</string>
 
     <!-- The remembered chat names -->
     <!-- "No chats remembered yet. Chats are listed here so per-contact rules need no typing." -->

--- a/app/src/main/res/values/strings_setup.xml
+++ b/app/src/main/res/values/strings_setup.xml
@@ -100,6 +100,10 @@
     <string name="setup_open_notif_access">Open notification access</string>
     <string name="setup_inspector_body">Shows what HiLight reads from each notification. No message text.</string>
     <string name="setup_inspector_button">Notification inspector</string>
+    <string name="setup_notif_until_dismissed">Stay on until dismissed</string>
+    <string name="setup_notif_until_dismissed_hint">Keeps the notification pattern playing until the notification is dismissed from the shade instead of turning off after a set duration.</string>
+    <string name="setup_notif_alternate_interval">Alternate pattern every</string>
+    <string name="setup_notif_alternate_hint">When multiple notifications are present, alternates between each notification\'s pattern and colour.</string>
 
     <!-- The remembered chat names, which exist so per-contact rules need no typing. Said two ways
          because an empty list has nothing to count. -->

--- a/app/src/test/java/com/hilight/studio/NotificationAlternationTest.kt
+++ b/app/src/test/java/com/hilight/studio/NotificationAlternationTest.kt
@@ -1,0 +1,124 @@
+package com.hilight.studio
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NotificationAlternationTest {
+
+    private val rule1 = AppRule(
+        pkg = "com.whatsapp",
+        label = "WhatsApp",
+        pattern = Pattern.PULSE,
+        color = 0xFF00E676.toInt(),
+        speedMs = 800,
+        brightness = 1f,
+    )
+
+    private val rule2 = AppRule(
+        pkg = "com.slack",
+        label = "Slack",
+        pattern = Pattern.WAVE,
+        color = 0xFF00E5FF.toInt(),
+        speedMs = 1200,
+        brightness = 0.8f,
+    )
+
+    private val rule3 = AppRule(
+        pkg = "org.telegram.messenger",
+        label = "Telegram",
+        pattern = Pattern.BREATHE,
+        color = 0xFFFF4081.toInt(),
+        speedMs = 600,
+        brightness = 0.9f,
+    )
+
+    @Test
+    fun `interval clamping enforces 2000 to 10000 ms`() {
+        val clampLow = 1000.coerceIn(2000, 10000)
+        val clampMid = 4000.coerceIn(2000, 10000)
+        val clampHigh = 20000.coerceIn(2000, 10000)
+
+        assertEquals(2000, clampLow)
+        assertEquals(4000, clampMid)
+        assertEquals(10000, clampHigh)
+    }
+
+    @Test
+    fun `active notification map tracks multiple notifications in order`() {
+        val map = LinkedHashMap<String, Store.ActiveNotificationAlert>()
+        val alert1 = Store.ActiveNotificationAlert("key1", rule1, rule1.color)
+        val alert2 = Store.ActiveNotificationAlert("key2", rule2, rule2.color)
+        val alert3 = Store.ActiveNotificationAlert("key3", rule3, rule3.color)
+
+        map["key1"] = alert1
+        map["key2"] = alert2
+        map["key3"] = alert3
+
+        assertEquals(3, map.size)
+        val list = map.values.toList()
+        assertEquals("key1", list[0].notifKey)
+        assertEquals("key2", list[1].notifKey)
+        assertEquals("key3", list[2].notifKey)
+    }
+
+    @Test
+    fun `alternation cycles through active notifications in round-robin order`() {
+        val list = listOf(
+            Store.ActiveNotificationAlert("key1", rule1, rule1.color),
+            Store.ActiveNotificationAlert("key2", rule2, rule2.color),
+            Store.ActiveNotificationAlert("key3", rule3, rule3.color),
+        )
+
+        var index = 0
+        assertEquals("com.whatsapp", list[index].rule.pkg)
+
+        index = (index + 1) % list.size
+        assertEquals("com.slack", list[index].rule.pkg)
+
+        index = (index + 1) % list.size
+        assertEquals("org.telegram.messenger", list[index].rule.pkg)
+
+        index = (index + 1) % list.size
+        assertEquals("com.whatsapp", list[index].rule.pkg)
+    }
+
+    @Test
+    fun `dismissing a notification adjusts index and keeps remaining active`() {
+        val map = LinkedHashMap<String, Store.ActiveNotificationAlert>()
+        map["key1"] = Store.ActiveNotificationAlert("key1", rule1, rule1.color)
+        map["key2"] = Store.ActiveNotificationAlert("key2", rule2, rule2.color)
+        map["key3"] = Store.ActiveNotificationAlert("key3", rule3, rule3.color)
+
+        var index = 2 // pointing to key3
+        map.remove("key3")
+        index = index % map.size
+
+        assertEquals(2, map.size)
+        assertEquals(0, index) // wrapped to 0 (key1)
+        val remaining = map.values.toList()
+        assertEquals("key1", remaining[index].notifKey)
+
+        map.remove("key1")
+        index = index % map.size
+        assertEquals(1, map.size)
+        assertEquals("key2", map.values.toList()[index].notifKey)
+
+        map.remove("key2")
+        assertTrue(map.isEmpty())
+    }
+
+    @Test
+    fun `screen off rule check correctly identifies if notification can flash`() {
+        val screenOffRule = rule1.copy(onlyWhenScreenOff = true)
+        val alwaysRule = rule2.copy(onlyWhenScreenOff = false)
+
+        val screenIsOn = true
+        val canFlashScreenOffRule = !(screenOffRule.onlyWhenScreenOff && screenIsOn)
+        val canFlashAlwaysRule = !(alwaysRule.onlyWhenScreenOff && screenIsOn)
+
+        assertFalse(canFlashScreenOffRule)
+        assertTrue(canFlashAlwaysRule)
+    }
+}


### PR DESCRIPTION
## Summary

Adds an option to keep notification patterns active on the rear LED array until dismissed from the notification shade (instead of stopping after a fixed time duration), along with round-robin multi-notification alternation:

- **"Stay on until dismissed" Setting:** Added a toggle and an "Alternate pattern every" interval slider (2s–10s, default 4s) under the Notification Access section in Setup (`SetupScreen.kt`).
- **Multi-Notification Alternation:** When multiple active notifications match configured rules, the LED array alternates between each notification's pattern and color every few seconds (`Store.kt`).
- **Dynamic Dismissal & Screen Lifecycle:** 
  - Dismissing any notification dynamically removes it from rotation; dismissing all notifications turns off the alert (`NotificationTrigger.kt`).
  - Turning the screen on temporarily pauses the rear light, and resuming occurs automatically when the screen turns off if notifications remain in the shade.
- **Unit Tests:** Added `NotificationAlternationTest` covering active notification tracking, interval bounds, round-robin ordering, and dismissal transitions.

## Verification

- [x] `./gradlew :app:testDebugUnitTest :app:build :app:lint`
- [x] Tested on a supported Pixel device, if renderer, transport, or timing changed
- [x] No notification contents or other personal data are included
