### PR TITLE
feat: add seven new LED animation patterns

### DIFF
--- a/app/src/main/java/com/hilight/studio/LiveScreen.kt
+++ b/app/src/main/java/com/hilight/studio/LiveScreen.kt
@@ -17,8 +17,11 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.AutoAwesome
 import androidx.compose.material.icons.rounded.Bolt
 import androidx.compose.material.icons.rounded.Casino
+import androidx.compose.material.icons.rounded.Favorite
 import androidx.compose.material.icons.rounded.Flare
+import androidx.compose.material.icons.rounded.FlashOn
 import androidx.compose.material.icons.rounded.Nightlight
+import androidx.compose.material.icons.rounded.Radar
 import androidx.compose.material.icons.rounded.Waves
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -187,11 +190,13 @@ fun LiveScreen(store: Store) {
     val tests: List<Triple<Int, ImageVector, Pair<Pattern, Int>>> = listOf(
         Triple(Pattern.RAINBOW.shortLabelRes, Icons.Rounded.AutoAwesome, Pattern.RAINBOW to 0xFFFFFFFF.toInt()),
         Triple(R.string.live_test_random, Icons.Rounded.Casino, Pattern.RANDOM to 0xFFFFFFFF.toInt()),
-        // tile accents are chosen for legibility; the effect colours themselves are above
+        Triple(Pattern.STROBE.shortLabelRes, Icons.Rounded.FlashOn, Pattern.STROBE to 0xFFFFFFFF.toInt()),
         Triple(Pattern.COMET.shortLabelRes, Icons.Rounded.Flare, Pattern.COMET to 0xFF00E5FF.toInt()),
         Triple(Pattern.PULSE.shortLabelRes, Icons.Rounded.Bolt, Pattern.PULSE to 0xFFFF1744.toInt()),
+        Triple(Pattern.HEARTBEAT.shortLabelRes, Icons.Rounded.Favorite, Pattern.HEARTBEAT to 0xFFFF1744.toInt()),
         Triple(Pattern.BREATHE.shortLabelRes, Icons.Rounded.Nightlight, Pattern.BREATHE to 0xFF7C4DFF.toInt()),
         Triple(Pattern.WAVE.shortLabelRes, Icons.Rounded.Waves, Pattern.WAVE to 0xFF00E676.toInt()),
+        Triple(Pattern.RADAR.shortLabelRes, Icons.Rounded.Radar, Pattern.RADAR to 0xFF00E5FF.toInt()),
     )
 
     PixelCard {

--- a/app/src/main/java/com/hilight/studio/Model.kt
+++ b/app/src/main/java/com/hilight/studio/Model.kt
@@ -42,6 +42,13 @@ enum class Pattern(
         "rainbow", R.string.pattern_rainbow, cycleMeaningRes = R.string.cycle_rainbow,
         narrowLabelRes = R.string.pattern_rainbow_short,
     ),
+    METER("meter", R.string.pattern_meter, cycleMeaningRes = R.string.cycle_meter),
+    STROBE("strobe", R.string.pattern_strobe, cycleMeaningRes = R.string.cycle_strobe),
+    HEARTBEAT("heartbeat", R.string.pattern_heartbeat, cycleMeaningRes = R.string.cycle_heartbeat),
+    BOUNCE("bounce", R.string.pattern_bounce, cycleMeaningRes = R.string.cycle_bounce),
+    RADAR("radar", R.string.pattern_radar, cycleMeaningRes = R.string.cycle_radar),
+    CONVERGE("converge", R.string.pattern_converge, cycleMeaningRes = R.string.cycle_converge),
+    GLITCH("glitch", R.string.pattern_glitch, cycleMeaningRes = R.string.cycle_glitch),
     RANDOM("random", R.string.pattern_random, usesSpeed = false),
     CUSTOM("custom", R.string.pattern_custom, usesSpeed = false);
 

--- a/app/src/main/java/com/hilight/studio/Preview.kt
+++ b/app/src/main/java/com/hilight/studio/Preview.kt
@@ -5,7 +5,9 @@ import kotlin.math.PI
 import kotlin.math.abs
 import kotlin.math.cos
 import kotlin.math.exp
+import kotlin.math.floor
 import kotlin.math.max
+import kotlin.math.min
 import kotlin.math.sin
 
 /**
@@ -71,6 +73,98 @@ object Renderer {
                 for (i in 0 until n) {
                     val h = (phase + if (cfg.rainbowSpread) i.toDouble() / n else 0.0) * 360.0
                     out[i] = hsv((h % 360).toFloat())
+                }
+            }
+
+            Pattern.METER -> {
+                val phase = (t % speed) / speed.toDouble()
+                if (phase < 0.75) {
+                    val progress = (phase / 0.75) * n
+                    val fullCount = floor(progress).toInt()
+                    val partial = progress - fullCount
+                    for (i in 0 until n) {
+                        if (i < fullCount) {
+                            out[i] = base
+                        } else if (i == fullCount) {
+                            out[i] = scale(base, partial)
+                        } else {
+                            out[i] = 0xFF000000.toInt()
+                        }
+                    }
+                } else if (phase < 0.88) {
+                    for (i in 0 until n) out[i] = base
+                } else {
+                    val fade = 1.0 - (phase - 0.88) / 0.12
+                    for (i in 0 until n) out[i] = scale(base, fade)
+                }
+            }
+
+            Pattern.STROBE -> {
+                val phase = (t % speed) / speed.toDouble()
+                if (phase < 0.45) {
+                    val subPhase = (phase / 0.45) * 3.0
+                    val frac = subPhase - floor(subPhase)
+                    if (frac < 0.55) {
+                        for (i in 0 until n) out[i] = base
+                    }
+                }
+            }
+
+            Pattern.HEARTBEAT -> {
+                val phase = (t % speed) / speed.toDouble()
+                val k = when {
+                    phase < 0.06 -> (phase / 0.06) * 0.75
+                    phase < 0.22 -> 0.75 * exp(-(phase - 0.06) * 16.0)
+                    phase < 0.28 -> ((phase - 0.22) / 0.06)
+                    phase < 0.60 -> exp(-(phase - 0.28) * 9.0)
+                    else -> 0.0
+                }
+                for (i in 0 until n) out[i] = scale(base, k)
+            }
+
+            Pattern.BOUNCE -> {
+                val phase = (t % speed) / speed.toDouble()
+                val pos = (if (phase < 0.5) (phase * 2.0) else ((1.0 - phase) * 2.0)) * (n - 1)
+                for (i in 0 until n) {
+                    val dist = abs(pos - i)
+                    out[i] = scale(base, max(0.0, 1.0 - dist / 1.5))
+                }
+            }
+
+            Pattern.RADAR -> {
+                val phase = (t % speed) / speed.toDouble()
+                val head = phase * n
+                for (i in 0 until n) {
+                    var d = head - i
+                    if (d < 0) d += n
+                    out[i] = scale(base, exp(-d * 0.55))
+                }
+            }
+
+            Pattern.CONVERGE -> {
+                val phase = (t % speed) / speed.toDouble()
+                val travel = if (phase < 0.5) (phase * 2.0) else ((1.0 - phase) * 2.0)
+                val centerDist = (n - 1) / 2.0
+                val p1 = travel * centerDist
+                val p2 = (n - 1) - travel * centerDist
+                val boost = if (travel > 0.85) (travel - 0.85) / 0.15 * 0.35 else 0.0
+                for (i in 0 until n) {
+                    val d1 = abs(p1 - i)
+                    val d2 = abs(p2 - i)
+                    val k = max(max(0.0, 1.0 - d1), max(0.0, 1.0 - d2)) + boost
+                    out[i] = scale(base, min(1.0, k))
+                }
+            }
+
+            Pattern.GLITCH -> {
+                for (i in 0 until n) {
+                    val seed = (i * 3 + 1) * 7
+                    val ledPeriod = max(80L, speed / 2 + (seed % 5) * 80L)
+                    val ledPhase = ((t + seed * 137L) % ledPeriod) / ledPeriod.toDouble()
+                    val spike = if (ledPhase < 0.15) (ledPhase / 0.15) else exp(-(ledPhase - 0.15) * 12.0)
+                    val jitter = if ((t / 40 + i * 5) % 3L == 0L && spike > 0.05) 0.3 else 0.0
+                    val k = (spike * 0.85 + jitter).coerceIn(0.0, 1.0)
+                    out[i] = scale(base, k)
                 }
             }
 

--- a/app/src/main/res/values-ja/strings_common.xml
+++ b/app/src/main/res/values-ja/strings_common.xml
@@ -44,6 +44,20 @@
     <string name="pattern_rainbow">レインボー</string>
     <!-- "Rainbow" — the narrow form, for tiles and fill buttons where レインボー wraps and clips -->
     <string name="pattern_rainbow_short">虹</string>
+    <!-- "Meter" -->
+    <string name="pattern_meter">メーター</string>
+    <!-- "Strobe" -->
+    <string name="pattern_strobe">ストロボ</string>
+    <!-- "Heartbeat" -->
+    <string name="pattern_heartbeat">ハートビート</string>
+    <!-- "Bounce" -->
+    <string name="pattern_bounce">バウンス</string>
+    <!-- "Radar" -->
+    <string name="pattern_radar">レーダー</string>
+    <!-- "Converge" -->
+    <string name="pattern_converge">コンバージ</string>
+    <!-- "Glitch" -->
+    <string name="pattern_glitch">グリッチ</string>
     <!-- "Random colours" -->
     <string name="pattern_random">ランダムな色</string>
     <!-- "Per-LED custom" -->
@@ -64,6 +78,20 @@
     <string name="cycle_wave">波が LED アレイを 1 回横切ります。</string>
     <!-- "One trip through every hue, back to the start." -->
     <string name="cycle_rainbow">すべての色相を一巡して元に戻ります。</string>
+    <!-- "One progressive fill from 1 to 8 LEDs, then resets." -->
+    <string name="cycle_meter">LED が 1 個ずつ順番に点灯していき、全点灯したあとに消灯します。</string>
+    <!-- "A rapid triplet strobe burst followed by a pause." -->
+    <string name="cycle_strobe">素早い 3 連ストロボ点滅のあと、一時停止します。</string>
+    <!-- "One double-pulse heartbeat rhythm followed by a rest." -->
+    <string name="cycle_heartbeat">トントンと 2 回連続で拍動し、余韻を残して消えます。</string>
+    <!-- "One back-and-forth bounce across the LEDs." -->
+    <string name="cycle_bounce">光が LED の端から端まで往復します。</string>
+    <!-- "One smooth rotational radar sweep around the array." -->
+    <string name="cycle_radar">レーダーの光がアレイを滑らかに 1 周スイープします。</string>
+    <!-- "Two beams collide at the centre and burst outwards." -->
+    <string name="cycle_converge">両端から光が集まって衝突し、外側へ広がります。</string>
+    <!-- "Erratic digital micro-sparks and cybernetic flickers." -->
+    <string name="cycle_glitch">サイバー感のある不規則なデジタル微光とスパークです。</string>
 
     <!-- Why the array is being held dark -->
     <!-- "Quiet hours" -->

--- a/app/src/main/res/values/strings_common.xml
+++ b/app/src/main/res/values/strings_common.xml
@@ -32,6 +32,13 @@
     <!-- Shown where a pattern name gets a third of a row: the Live tab's effect tiles and the
          per-LED fill buttons. Same word in English; Japanese needs a shorter one. -->
     <string name="pattern_rainbow_short">Rainbow</string>
+    <string name="pattern_meter">Meter</string>
+    <string name="pattern_strobe">Strobe</string>
+    <string name="pattern_heartbeat">Heartbeat</string>
+    <string name="pattern_bounce">Bounce</string>
+    <string name="pattern_radar">Radar</string>
+    <string name="pattern_converge">Converge</string>
+    <string name="pattern_glitch">Glitch</string>
     <string name="pattern_random">Random colours</string>
     <string name="pattern_custom">Per-LED custom</string>
 
@@ -43,6 +50,13 @@
     <string name="cycle_comet">One lap of the comet head, its tail trailing 3 LEDs.</string>
     <string name="cycle_wave">One wave travelling once across the array.</string>
     <string name="cycle_rainbow">One trip through every hue, back to the start.</string>
+    <string name="cycle_meter">One progressive fill from 1 to 8 LEDs, then resets.</string>
+    <string name="cycle_strobe">A rapid triplet strobe burst followed by a pause.</string>
+    <string name="cycle_heartbeat">One double-pulse heartbeat rhythm followed by a rest.</string>
+    <string name="cycle_bounce">One back-and-forth bounce across the LEDs.</string>
+    <string name="cycle_radar">One smooth rotational radar sweep around the array.</string>
+    <string name="cycle_converge">Two beams collide at the centre and burst outwards.</string>
+    <string name="cycle_glitch">Erratic digital micro-sparks and cybernetic flickers.</string>
 
     <!-- Why the array is being held dark -->
     <string name="suppression_quiet_hours">Quiet hours</string>

--- a/app/src/test/java/com/hilight/studio/GlyphPatternsTest.kt
+++ b/app/src/test/java/com/hilight/studio/GlyphPatternsTest.kt
@@ -1,0 +1,107 @@
+package com.hilight.studio
+
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GlyphPatternsTest {
+
+    private val javaRenderer = com.hilight.core.Renderer()
+
+    private fun isFrameVisible(frame: IntArray): Boolean {
+        for (color in frame) {
+            val rgb = ((color shr 16) and 0xFF) + ((color shr 8) and 0xFF) + (color and 0xFF)
+            if (rgb > 12) return true
+        }
+        return false
+    }
+
+    @Test
+    fun allNewPatternsProduceValidFramesInJavaRenderer() {
+        val patterns = listOf("meter", "strobe", "heartbeat", "bounce", "radar", "converge", "glitch")
+        val color = 0xFF00E676L
+        val speedMs = 1000L
+
+        for (mode in patterns) {
+            val cfg = JSONObject().apply {
+                put("mode", mode)
+                put("color", color)
+                put("speedMs", speedMs)
+                put("brightness", 1.0)
+            }
+
+            var hasVisibleFrame = false
+            for (t in 0..1000 step 50) {
+                val frame = javaRenderer.frame(cfg, t.toLong(), 8)
+                assertEquals("Frame size must be 8 for mode $mode", 8, frame.size)
+                for (pixel in frame) {
+                    val alpha = (pixel ushr 24) and 0xFF
+                    val red = (pixel ushr 16) and 0xFF
+                    val green = (pixel ushr 8) and 0xFF
+                    val blue = pixel and 0xFF
+                    assertTrue("Alpha must be 0 or 255", alpha == 0 || alpha == 0xFF)
+                    assertTrue("Red channel in bounds", red in 0..255)
+                    assertTrue("Green channel in bounds", green in 0..255)
+                    assertTrue("Blue channel in bounds", blue in 0..255)
+                }
+                if (isFrameVisible(frame)) {
+                    hasVisibleFrame = true
+                }
+            }
+            assertTrue("Pattern $mode should produce at least one visible frame during cycle", hasVisibleFrame)
+        }
+    }
+
+    @Test
+    fun allNewPatternsProduceValidFramesInKotlinPreview() {
+        val glyphPatterns = listOf(
+            Pattern.METER,
+            Pattern.STROBE,
+            Pattern.HEARTBEAT,
+            Pattern.BOUNCE,
+            Pattern.RADAR,
+            Pattern.CONVERGE,
+            Pattern.GLITCH,
+        )
+
+        for (pattern in glyphPatterns) {
+            val ambient = Ambient(
+                pattern = pattern,
+                color = 0xFF00E5FF.toInt(),
+                speedMs = 1000,
+                brightness = 1f,
+            )
+
+            var hasVisibleFrame = false
+            for (t in 0..1000 step 50) {
+                val frame = Renderer.frame(pattern, t.toLong(), ambient)
+                assertEquals(8, frame.size)
+                if (isFrameVisible(frame)) {
+                    hasVisibleFrame = true
+                }
+            }
+            assertTrue("Preview for $pattern should produce at least one visible frame", hasVisibleFrame)
+        }
+    }
+
+    @Test
+    fun patternEnumResolutionAndRoundTrip() {
+        val glyphPatterns = listOf(
+            Pattern.METER to "meter",
+            Pattern.STROBE to "strobe",
+            Pattern.HEARTBEAT to "heartbeat",
+            Pattern.BOUNCE to "bounce",
+            Pattern.RADAR to "radar",
+            Pattern.CONVERGE to "converge",
+            Pattern.GLITCH to "glitch",
+        )
+
+        for ((pat, key) in glyphPatterns) {
+            assertEquals(key, pat.key)
+            assertEquals(pat, Pattern.of(key))
+            assertTrue(pat.usesSpeed)
+            assertTrue(pat.cycleMeaningRes != null)
+        }
+    }
+}

--- a/core/src/com/hilight/core/Renderer.java
+++ b/core/src/com/hilight/core/Renderer.java
@@ -110,6 +110,110 @@ public final class Renderer {
                 break;
             }
 
+            case "meter": {
+                double phase = (t % speed) / (double) speed;
+                if (phase < 0.75) {
+                    double progress = (phase / 0.75) * n;
+                    int fullCount = (int) Math.floor(progress);
+                    double partial = progress - fullCount;
+                    for (int i = 0; i < n; i++) {
+                        if (i < fullCount) {
+                            out[i] = palette[i % palette.length];
+                        } else if (i == fullCount) {
+                            out[i] = scale(palette[i % palette.length], partial);
+                        } else {
+                            out[i] = 0xFF000000;
+                        }
+                    }
+                } else if (phase < 0.88) {
+                    for (int i = 0; i < n; i++) out[i] = palette[i % palette.length];
+                } else {
+                    double fade = 1.0 - (phase - 0.88) / 0.12;
+                    for (int i = 0; i < n; i++) out[i] = scale(palette[i % palette.length], fade);
+                }
+                break;
+            }
+
+            case "strobe": {
+                double phase = (t % speed) / (double) speed;
+                if (phase < 0.45) {
+                    double subPhase = (phase / 0.45) * 3.0;
+                    double frac = subPhase - Math.floor(subPhase);
+                    if (frac < 0.55) {
+                        for (int i = 0; i < n; i++) out[i] = palette[i % palette.length];
+                    }
+                }
+                break;
+            }
+
+            case "heartbeat": {
+                double phase = (t % speed) / (double) speed;
+                double k;
+                if (phase < 0.06) {
+                    k = (phase / 0.06) * 0.75;
+                } else if (phase < 0.22) {
+                    k = 0.75 * Math.exp(-(phase - 0.06) * 16.0);
+                } else if (phase < 0.28) {
+                    k = ((phase - 0.22) / 0.06);
+                } else if (phase < 0.60) {
+                    k = Math.exp(-(phase - 0.28) * 9.0);
+                } else {
+                    k = 0.0;
+                }
+                for (int i = 0; i < n; i++) out[i] = scale(palette[i % palette.length], k);
+                break;
+            }
+
+            case "bounce": {
+                double phase = (t % speed) / (double) speed;
+                double pos = (phase < 0.5 ? (phase * 2.0) : ((1.0 - phase) * 2.0)) * (n - 1);
+                for (int i = 0; i < n; i++) {
+                    double dist = Math.abs(pos - i);
+                    out[i] = scale(palette[i % palette.length], Math.max(0.0, 1.0 - dist / 1.5));
+                }
+                break;
+            }
+
+            case "radar": {
+                double phase = (t % speed) / (double) speed;
+                double head = phase * n;
+                for (int i = 0; i < n; i++) {
+                    double d = head - i;
+                    if (d < 0) d += n;
+                    out[i] = scale(palette[i % palette.length], Math.exp(-d * 0.55));
+                }
+                break;
+            }
+
+            case "converge": {
+                double phase = (t % speed) / (double) speed;
+                double travel = phase < 0.5 ? (phase * 2.0) : ((1.0 - phase) * 2.0);
+                double centerDist = (n - 1) / 2.0;
+                double p1 = travel * centerDist;
+                double p2 = (n - 1) - travel * centerDist;
+                double boost = travel > 0.85 ? (travel - 0.85) / 0.15 * 0.35 : 0.0;
+                for (int i = 0; i < n; i++) {
+                    double d1 = Math.abs(p1 - i);
+                    double d2 = Math.abs(p2 - i);
+                    double k = Math.max(Math.max(0.0, 1.0 - d1), Math.max(0.0, 1.0 - d2)) + boost;
+                    out[i] = scale(palette[i % palette.length], Math.min(1.0, k));
+                }
+                break;
+            }
+
+            case "glitch": {
+                for (int i = 0; i < n; i++) {
+                    int seed = (i * 3 + 1) * 7;
+                    long ledPeriod = Math.max(80, speed / 2 + (seed % 5) * 80);
+                    double ledPhase = ((t + seed * 137L) % ledPeriod) / (double) ledPeriod;
+                    double spike = ledPhase < 0.15 ? (ledPhase / 0.15) : Math.exp(-(ledPhase - 0.15) * 12.0);
+                    double jitter = ((t / 40 + i * 5) % 3 == 0 && spike > 0.05) ? 0.3 : 0.0;
+                    double k = clamp01(spike * 0.85 + jitter);
+                    out[i] = scale(palette[i % palette.length], k);
+                }
+                break;
+            }
+
             case "random": {
                 long interval = Math.max(120, cfg.optLong("randomIntervalMs", 1500));
                 boolean perLed = cfg.optBoolean("randomPerLed", true);

--- a/docs/i18n/ja-review.md
+++ b/docs/i18n/ja-review.md
@@ -39,6 +39,13 @@ Leave Latin as-is: HiLight, Shizuku, ADB, LED, JSON, MessagingStyle, shortcutId,
 | `pattern_wave` | Wave | ウェーブ |
 | `pattern_rainbow` | Rainbow | レインボー |
 | `pattern_rainbow_short` | Rainbow | 虹 |
+| `pattern_meter` | Meter | メーター |
+| `pattern_strobe` | Strobe | ストロボ |
+| `pattern_heartbeat` | Heartbeat | ハートビート |
+| `pattern_bounce` | Bounce | バウンス |
+| `pattern_radar` | Radar | レーダー |
+| `pattern_converge` | Converge | コンバージ |
+| `pattern_glitch` | Glitch | グリッチ |
 | `pattern_random` | Random colours | ランダムな色 |
 | `pattern_custom` | Per-LED custom | LED ごとに設定 |
 | `cycle_breathe` | One full breath: dim up to full, back down. | ひと呼吸分です。暗い状態から最大まで明るくなり、また暗くなります。 |
@@ -48,6 +55,13 @@ Leave Latin as-is: HiLight, Shizuku, ADB, LED, JSON, MessagingStyle, shortcutId,
 | `cycle_comet` | One lap of the comet head, its tail trailing 3 LEDs. | コメットの先頭が 1 周します。尾は LED 3 個分です。 |
 | `cycle_wave` | One wave travelling once across the array. | 波が LED アレイを 1 回横切ります。 |
 | `cycle_rainbow` | One trip through every hue, back to the start. | すべての色相を一巡して元に戻ります。 |
+| `cycle_meter` | One progressive fill from 1 to 8 LEDs, then resets. | LED が 1 個ずつ順番に点灯していき、全点灯したあとに消灯します。 |
+| `cycle_strobe` | A rapid triplet strobe burst followed by a pause. | 素早い 3 連ストロボ点滅のあと、一時停止します。 |
+| `cycle_heartbeat` | One double-pulse heartbeat rhythm followed by a rest. | トントンと 2 回連続で拍動し、余韻を残して消えます。 |
+| `cycle_bounce` | One back-and-forth bounce across the LEDs. | 光が LED の端から端まで往復します。 |
+| `cycle_radar` | One smooth rotational radar sweep around the array. | レーダーの光がアレイを滑らかに 1 周スイープします。 |
+| `cycle_converge` | Two beams collide at the centre and burst outwards. | 両端から光が集まって衝突し、外側へ広がります。 |
+| `cycle_glitch` | Erratic digital micro-sparks and cybernetic flickers. | サイバー感のある不規則なデジタル微光とスパークです。 |
 | `suppression_quiet_hours` | Quiet hours | サイレント時間 |
 | `suppression_low_battery` | Low battery | 電池残量が少ない |
 | `suppression_power_saver` | Battery Saver | バッテリーセーバー |


### PR DESCRIPTION
## Summary

Added 7 new animation patterns inspired by the Nothing Phone (1) / (2) Glyph lighting interface for the 8-LED HiLight ring array:

- **Meter (`meter`)**: Sequential 1-to-8 LED progressive fill and hold inspired by Phone (2)'s 16-LED Glyph progress and timer arc.
- **Strobe (`strobe`)**: High-energy staccato triplet flash bursts with a rhythmic pause, modeled after Nothing's *Coded* and *Radiate* ringtone sequences.
- **Heartbeat (`heartbeat`)**: Biometric double-pulse alert cadence (*lub-dub*) with asymmetric systolic/diastolic decay.
- **Bounce (`bounce`)**: Smooth bidirectional scanner oscillating back and forth across the LEDs with soft falloff.
- **Radar (`radar`)**: Rotational sonar sweep with a sharp leading edge and an expansive exponential decay tail.
- **Converge (`converge`)**: Symmetrical twin beams traveling inward from opposite sides, bursting upon center collision, and receding.
- **Glitch (`glitch`)**: Cybernetic micro-sparks and asynchronous digital jitter across individual LED channels.

### Key Changes
- **Core Renderer (`Renderer.java`)**: Implemented the frame rendering mathematics in the shared renderer engine for all 7 modes.
- **UI Previews (`Preview.kt`)**: Added matching Kotlin mathematical models so all Compose on-screen previews (Hero device, LedStrip, and effect carousels) display identical animations.
- **Data Models & UI (`Model.kt`, `LiveScreen.kt`)**: Added `Pattern` enum entries with cycle metadata and test tiles in the Live tab for Strobe, Heartbeat, and Radar.
- **Localization (`strings_common.xml`, `values-ja/strings_common.xml`, `ja-review.md`)**: Added English and Japanese names and cycle descriptions following the localization glossary.
- **Automated Tests (`GlyphPatternsTest.kt`)**: Added unit test coverage validating frame bounds, visibility, and pattern resolution across both Java core and Kotlin preview renderers.

## Verification

- [x] `./gradlew :app:testDebugUnitTest :app:build :app:lint`
- [x] Tested on a supported Pixel device, if renderer, transport, or timing changed
- [x] No notification contents or other personal data are included
