### PR TITLE
Prepare v1.0.11 feedback fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to HiLight Studio are documented here.
 
 ## [Unreleased]
 
+- Kept an ordinary notification alert running when the notification itself wakes the screen, while
+  still stopping it on unlock and still stopping per-rule **Only while the screen is off** alerts as
+  soon as the screen wakes. This addresses the lifecycle sequence reported for Discord's first alert
+  and still needs confirmation on the reporter's device.
+- Added a clear message when an in-app preview or end-to-end notification test is currently blocked
+  by quiet hours, Battery Saver, low battery, or the applicable face-down guard.
+- Split the former **When to stay dark** settings into **When HiLight can glow** and **When HiLight
+  should pause**, with each live suppression reason shown beside the section that controls it.
+- Added a compact Dhananjay Tech attribution link at the top of Settings.
+
 ## [1.0.10-experimental] - 2026-08-29
 
 - Bumped the privileged renderer implementation revision to 5 so Shizuku, ADB, and root restart an

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -29,8 +29,8 @@ android {
         // supported hardware prevents installation on devices the renderer cannot support.
         minSdk = 37
         targetSdk = 37
-        versionCode = 11
-        versionName = "1.0.10"
+        versionCode = 12
+        versionName = "1.0.11"
     }
 
     signingConfigs {

--- a/app/src/main/java/com/hilight/studio/AppRulesScreen.kt
+++ b/app/src/main/java/com/hilight/studio/AppRulesScreen.kt
@@ -83,6 +83,7 @@ private data class RuleEditorState(val rule: AppRule, val isNew: Boolean)
 @Composable
 fun AppRulesScreen(store: Store) {
     val ctx = LocalContext.current
+    val launchPreview = rememberPreviewLauncher(store)
     val rules by store.rules.collectAsStateWithLifecycle()
     val privacyRules by store.privacyRules.collectAsStateWithLifecycle()
     val conversations by store.conversations.collectAsStateWithLifecycle()
@@ -151,7 +152,7 @@ fun AppRulesScreen(store: Store) {
                     onEdit = { editing = RuleEditorState(rule, isNew = false) },
                     onTest = {
                         // test what the rule will actually do, including how long it stays lit
-                        store.preview(
+                        launchPreview(
                             rule.pattern, rule.color, rule.speedMs, rule.brightness, rule.durationMs,
                         )
                     },
@@ -169,7 +170,7 @@ fun AppRulesScreen(store: Store) {
         },
         onToggle = { store.upsertPrivacyRule(it.copy(enabled = !it.enabled), replacing = it) },
         onEdit = { editingPrivacy = it },
-        onTest = { store.preview(it.pattern, it.color, it.speedMs, it.brightness, it.lightMs) },
+        onTest = { launchPreview(it.pattern, it.color, it.speedMs, it.brightness, it.lightMs) },
         onDelete = store::removePrivacyRule,
     )
 
@@ -244,7 +245,9 @@ fun AppRulesScreen(store: Store) {
                 store.upsertRule(it, replacing = rule)
                 editing = null
             },
-            onTest = { store.preview(it.pattern, it.color, it.speedMs, it.brightness, it.durationMs) },
+            onTest = {
+                launchPreview(it.pattern, it.color, it.speedMs, it.brightness, it.durationMs)
+            },
             faceDownNoticeAccepted = faceDownNoticeAccepted,
             faceDownSensorAvailable = faceDownSensorAvailable,
             faceDownState = faceDownState,
@@ -317,7 +320,9 @@ fun AppRulesScreen(store: Store) {
                 store.upsertPrivacyRule(it, replacing = rule)
                 editingPrivacy = null
             },
-            onTest = { store.preview(it.pattern, it.color, it.speedMs, it.brightness, it.lightMs) },
+            onTest = {
+                launchPreview(it.pattern, it.color, it.speedMs, it.brightness, it.lightMs)
+            },
         )
     }
 }

--- a/app/src/main/java/com/hilight/studio/Guards.kt
+++ b/app/src/main/java/com/hilight/studio/Guards.kt
@@ -55,6 +55,19 @@ data class GuardState(
     }
 }
 
+/** Manual previews intentionally bypass only the face-down gate, matching [outputSuppression]. */
+internal fun GuardState.previewSuppressionReason(): Suppression? =
+    copy(faceDownOnly = false).alertSuppression()
+
+internal enum class SettingsSuppressionSection { GLOW, PAUSE }
+
+/** Routes the live explanation to the settings group that owns the condition. */
+internal fun Suppression.settingsSection(): SettingsSuppressionSection = when (this) {
+    Suppression.SCREEN_ON, Suppression.NOT_FACE_DOWN -> SettingsSuppressionSection.GLOW
+    Suppression.QUIET_HOURS, Suppression.POWER_SAVER, Suppression.LOW_BATTERY ->
+        SettingsSuppressionSection.PAUSE
+}
+
 /** Manual finite previews bypass only the face-down gate; every power/safety guard still applies. */
 internal fun GuardState.outputSuppression(
     hasTransientAlert: Boolean,

--- a/app/src/main/java/com/hilight/studio/LiveScreen.kt
+++ b/app/src/main/java/com/hilight/studio/LiveScreen.kt
@@ -93,6 +93,7 @@ private fun tileAccent(pattern: Pattern, color: Int): Color = when {
 /** Home surface: the phone itself, the master switch, and one-tap effects. */
 @Composable
 fun LiveScreen(store: Store) {
+    val launchPreview = rememberPreviewLauncher(store)
     val enabled by store.enabled.collectAsStateWithLifecycle()
     val ambient by store.ambient.collectAsStateWithLifecycle()
     val status by store.status.collectAsStateWithLifecycle()
@@ -211,7 +212,7 @@ fun LiveScreen(store: Store) {
                             accent = tileAccent(spec.first, spec.second),
                             enabled = enabled && status.alive,
                             modifier = Modifier.weight(1f),
-                        ) { store.preview(spec.first, spec.second, 1200, 1f) }
+                        ) { launchPreview(spec.first, spec.second, 1200, 1f, 4_000) }
                     }
                 }
             }

--- a/app/src/main/java/com/hilight/studio/SetupScreen.kt
+++ b/app/src/main/java/com/hilight/studio/SetupScreen.kt
@@ -36,7 +36,12 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -76,6 +81,8 @@ private const val ADB_PHONE_RESET =
         "kill -TERM ${'$'}p 2>/dev/null || exit 1; live=1; fi; done; " +
         "[ -n \"${'$'}live\" ] && sleep 0.1; i=${'$'}((i + 1)); done; " +
         "[ -z \"${'$'}live\" ] || exit 1"
+
+private const val DHANANJAY_TECH_URL = "https://twitter.com/Dhananjay_Tech"
 
 private const val ADB_PHONE_RESET_CMD =
     "live=1; i=0; while [ ${'$'}i -lt 65 ] && [ ${'$'}live = 1 ]; do live=0; " +
@@ -128,6 +135,7 @@ const val ADB_COMMAND_CMD =
 @Composable
 fun SetupScreen(store: Store) {
     val ctx = LocalContext.current
+    val resources = LocalResources.current
     val status by store.status.collectAsStateWithLifecycle()
     val masterEnabled by store.enabled.collectAsStateWithLifecycle()
     val manualCleanupPending by store.manualLedCleanupPending.collectAsStateWithLifecycle()
@@ -155,6 +163,12 @@ fun SetupScreen(store: Store) {
     val faceDownNoticeAccepted by store.faceDownNoticeAccepted.collectAsStateWithLifecycle()
     val faceDownState by store.faceDownState.collectAsStateWithLifecycle()
     val faceDownSensorAvailable = remember(ctx) { ForegroundWatcher.hasFaceDownSensor(ctx) }
+    val glowSuppression = suppression?.takeIf {
+        it.settingsSection() == SettingsSuppressionSection.GLOW
+    }
+    val pauseSuppression = suppression?.takeIf {
+        it.settingsSection() == SettingsSuppressionSection.PAUSE
+    }
 
     var notifAccess by remember { mutableStateOf(hasNotificationAccess(ctx)) }
     var usageAccess by remember { mutableStateOf(ForegroundWatcher.hasUsageAccess(ctx)) }
@@ -166,6 +180,28 @@ fun SetupScreen(store: Store) {
     var confirmingFaceDown by remember { mutableStateOf(false) }
     val updateScope = rememberCoroutineScope()
     val conversations by store.conversations.collectAsStateWithLifecycle()
+
+    val postSelfTest: () -> Unit = {
+        val reason = store.notificationTestSuppressionReason()
+        if (!store.enabled.value) {
+            Toast.makeText(
+                ctx.applicationContext,
+                R.string.setup_test_blocked_hilight_off,
+                Toast.LENGTH_SHORT,
+            ).show()
+        } else if (reason == null) {
+            postSelfTestNotification(ctx.applicationContext)
+        } else {
+            Toast.makeText(
+                ctx.applicationContext,
+                resources.getString(
+                    R.string.test_blocked_by_guard,
+                    resources.getString(reason.shortRes),
+                ),
+                Toast.LENGTH_SHORT,
+            ).show()
+        }
+    }
 
     val checkForUpdates: () -> Unit = {
         checkingForUpdates = true
@@ -184,6 +220,20 @@ fun SetupScreen(store: Store) {
             store.shizuku.refresh()
             delay(1500)
         }
+    }
+
+    val attribution = stringResource(R.string.setup_attribution)
+    val attributionLink = stringResource(R.string.setup_attribution_external)
+    PixelCard(
+        modifier = Modifier.semantics(mergeDescendants = true) {
+            role = Role.Button
+            contentDescription = "$attribution. $attributionLink"
+        },
+        tone = 0,
+        onClick = { openExternalUrl(ctx, DHANANJAY_TECH_URL) },
+    ) {
+        SectionTitle(attribution)
+        Caption(attributionLink)
     }
 
     PixelCard(tone = 2) {
@@ -210,8 +260,10 @@ fun SetupScreen(store: Store) {
 
     PixelCard {
         SectionTitle(
-            stringResource(R.string.setup_dark_title),
-            trailing = { suppression?.let { LivePill(stringResource(it.shortRes), ok = false) } },
+            stringResource(R.string.setup_glow_conditions_title),
+            trailing = {
+                glowSuppression?.let { LivePill(stringResource(it.shortRes), ok = false) }
+            },
         )
         ToggleRow(stringResource(R.string.setup_screen_off_only), screenOffOnly) {
             store.setScreenOffOnly(it)
@@ -254,8 +306,15 @@ fun SetupScreen(store: Store) {
                 )
             }
         }
-        // The toggle and the suppression pill above say the same two words about the same thing, so
-        // they share the one string.
+    }
+
+    PixelCard {
+        SectionTitle(
+            stringResource(R.string.setup_pause_conditions_title),
+            trailing = {
+                pauseSuppression?.let { LivePill(stringResource(it.shortRes), ok = false) }
+            },
+        )
         ToggleRow(stringResource(R.string.suppression_quiet_hours), quietEnabled) {
             store.setQuietHours(it)
         }
@@ -467,7 +526,7 @@ fun SetupScreen(store: Store) {
         val available = updateResult as? UpdateCheckResult.Available
         if (available != null && !checkingForUpdates) {
             Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-                Button(onClick = { openRelease(ctx, available.release.pageUrl) }) {
+                Button(onClick = { openExternalUrl(ctx, available.release.pageUrl) }) {
                     ButtonLabel(stringResource(R.string.setup_updates_view_release))
                 }
                 TextButton(onClick = checkForUpdates) {
@@ -494,7 +553,7 @@ fun SetupScreen(store: Store) {
         Caption(stringResource(R.string.setup_test_body))
         Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(10.dp)) {
             FilledTonalButton(
-                onClick = { postSelfTestNotification(ctx.applicationContext) },
+                onClick = postSelfTest,
                 enabled = selfTestCountdown == 0,
                 modifier = Modifier.weight(1f),
             ) {
@@ -506,14 +565,13 @@ fun SetupScreen(store: Store) {
                     // before Compose has redrawn the disabled button.
                     if (selfTestCountdown != 0) return@TextButton
                     selfTestCountdown = 5
-                    val appContext = ctx.applicationContext
                     updateScope.launch {
                         try {
                             for (remaining in 5 downTo 1) {
                                 selfTestCountdown = remaining
                                 delay(1_000)
                             }
-                            postSelfTestNotification(appContext)
+                            postSelfTest()
                         } finally {
                             selfTestCountdown = 0
                         }
@@ -770,7 +828,7 @@ private fun openShizukuListing(ctx: Context) {
         .onFailure { Toast.makeText(ctx, R.string.setup_no_browser, Toast.LENGTH_SHORT).show() }
 }
 
-private fun openRelease(ctx: Context, pageUrl: String) {
+private fun openExternalUrl(ctx: Context, pageUrl: String) {
     val uri = Uri.parse(pageUrl)
     runCatching { ctx.startActivity(Intent(Intent.ACTION_VIEW, uri)) }
         .onFailure { Toast.makeText(ctx, R.string.setup_no_browser, Toast.LENGTH_SHORT).show() }

--- a/app/src/main/java/com/hilight/studio/Store.kt
+++ b/app/src/main/java/com/hilight/studio/Store.kt
@@ -257,6 +257,27 @@ internal fun canRetryLedCleanup(
     !status.sessionOpen && status.blackClearTerminal && !status.blackClearPending &&
     !status.privacyObserverEnabled
 
+internal enum class ScreenLifecycleAction {
+    ARM_AND_REFRESH,
+    CANCEL_AND_REFRESH,
+    REFRESH_ONLY,
+}
+
+/** Keeps ordinary alerts alive across a screen wake while preserving screen-off-only rules. */
+internal fun screenLifecycleAction(
+    action: String?,
+    alertScreenOffGated: Boolean,
+): ScreenLifecycleAction = when (action) {
+    Intent.ACTION_SCREEN_OFF -> ScreenLifecycleAction.ARM_AND_REFRESH
+    Intent.ACTION_USER_PRESENT -> ScreenLifecycleAction.CANCEL_AND_REFRESH
+    Intent.ACTION_SCREEN_ON -> if (alertScreenOffGated) {
+        ScreenLifecycleAction.CANCEL_AND_REFRESH
+    } else {
+        ScreenLifecycleAction.REFRESH_ONLY
+    }
+    else -> ScreenLifecycleAction.REFRESH_ONLY
+}
+
 /**
  * Single source of truth for the UI and the triggers, and the only thing that pushes to a [Backend].
  *
@@ -429,6 +450,7 @@ class Store private constructor(private val app: Context) {
     private var activeAlert: JSONObject? = null
     private var activeAlertSource: AlertSource? = null
     private var activeAlertFaceDownGated = false
+    private var activeAlertScreenOffGated = false
     private var alertExpiry: Runnable? = null
     private var stateRevision = SystemClock.elapsedRealtime()
     private var rootTransition = false
@@ -500,18 +522,18 @@ class Store private constructor(private val app: Context) {
         app.registerReceiver(
             object : android.content.BroadcastReceiver() {
                 override fun onReceive(c: Context?, i: Intent?) {
-                    when (i?.action) {
-                        Intent.ACTION_SCREEN_OFF -> refreshSuppression(armOnRelease = true)
-                        Intent.ACTION_SCREEN_ON, Intent.ACTION_USER_PRESENT -> {
-                            // The screen coming on, or the phone being unlocked, means the
-                            // notification has been seen — a rule's colour has no one left to tell,
-                            // so drop it now instead of burning the rest of its window.
+                    when (screenLifecycleAction(i?.action, activeAlertScreenOffGated)) {
+                        ScreenLifecycleAction.ARM_AND_REFRESH ->
+                            refreshSuppression(armOnRelease = true)
+                        ScreenLifecycleAction.CANCEL_AND_REFRESH -> {
+                            // Unlocking means the notification has been seen. A screen wake alone
+                            // cancels only a rule that explicitly requires the screen to stay off.
                             cancelAlert()
                             refreshSuppression()
                         }
-                        // plugging in, unplugging, or toggling Battery Saver: re-check, but a power
-                        // event is not the user looking at the phone, so any alert keeps running
-                        else -> refreshSuppression()
+                        // A plain wake, power connection change, or Battery Saver change re-checks
+                        // the guards without cutting short an ordinary notification alert.
+                        ScreenLifecycleAction.REFRESH_ONLY -> refreshSuppression()
                     }
                 }
             },
@@ -1288,6 +1310,7 @@ class Store private constructor(private val app: Context) {
             preview = null,
             source = AlertSource.NOTIFICATION,
             faceDownGated = rule.onlyWhenFaceDown,
+            screenOffGated = rule.onlyWhenScreenOff,
         )
     }
 
@@ -1306,10 +1329,12 @@ class Store private constructor(private val app: Context) {
         preview: Ambient?,
         source: AlertSource,
         faceDownGated: Boolean = false,
+        screenOffGated: Boolean = false,
     ) {
         activeAlert = alert
         activeAlertSource = source
         activeAlertFaceDownGated = faceDownGated
+        activeAlertScreenOffGated = screenOffGated
         alertIsPreview = preview != null
         _previewLook.value = preview
         // A preview is a deliberate "show me this now", so it lights the array even with the master
@@ -1330,6 +1355,7 @@ class Store private constructor(private val app: Context) {
         activeAlert = null
         activeAlertSource = null
         activeAlertFaceDownGated = false
+        activeAlertScreenOffGated = false
         alertIsPreview = false
         _previewLook.value = null
         pushCurrent(arm = false)       // handing the layer back must not extend the ambient window
@@ -1338,8 +1364,8 @@ class Store private constructor(private val app: Context) {
     /**
      * Drops a notification alert that is still running, restoring whatever sits underneath it.
      *
-     * Called when the user turns the screen on or unlocks: the alert exists to be noticed, so once it
-     * has been there is nothing to keep lit. No-op when no alert is in flight.
+     * Called when the user unlocks, a screen-off-only rule sees the screen wake, or a face-down gate
+     * is left. No-op when no alert is in flight.
      */
     fun cancelAlert() {
         if (activeAlert == null) return
@@ -1392,6 +1418,12 @@ class Store private constructor(private val app: Context) {
             source = AlertSource.PREVIEW,
         )
     }
+
+    /** The same preview guard decision the renderer will apply, excluding the deliberate face gate bypass. */
+    fun previewSuppressionReason(): Suppression? = guardState().previewSuppressionReason()
+
+    /** Current pre-check for a real notification self-test, which follows notification guards. */
+    fun notificationTestSuppressionReason(): Suppression? = guardState().alertSuppression()
 
     /**
      * Kills a running preview. Called when the app leaves the foreground: a test the user started by

--- a/app/src/main/java/com/hilight/studio/Widgets.kt
+++ b/app/src/main/java/com/hilight/studio/Widgets.kt
@@ -1,5 +1,6 @@
 package com.hilight.studio
 
+import android.widget.Toast
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
@@ -23,6 +24,7 @@ import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
@@ -30,6 +32,8 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 
@@ -37,6 +41,32 @@ val PRESET_COLORS = listOf(
     0xFFFF1744, 0xFFFF6D00, 0xFFFFD600, 0xFF00E676, 0xFF00E5FF,
     0xFF2979FF, 0xFF7C4DFF, 0xFFFF4081, 0xFFFFFFFF, 0xFFFF80AB,
 ).map { it.toInt() }
+
+internal typealias PreviewLauncher = (Pattern, Int, Int, Float, Int) -> Unit
+
+/** Launches every in-app preview through one truthful guard check without adding UI controls. */
+@Composable
+internal fun rememberPreviewLauncher(store: Store): PreviewLauncher {
+    val context = LocalContext.current.applicationContext
+    val resources = LocalResources.current
+    return remember(store, context, resources) {
+        { pattern, color, speedMs, brightness, durationMs ->
+            val reason = store.previewSuppressionReason()
+            if (reason == null) {
+                store.preview(pattern, color, speedMs, brightness, durationMs)
+            } else {
+                Toast.makeText(
+                    context,
+                    resources.getString(
+                        R.string.test_blocked_by_guard,
+                        resources.getString(reason.shortRes),
+                    ),
+                    Toast.LENGTH_SHORT,
+                ).show()
+            }
+        }
+    }
+}
 
 /**
  * Swatches plus hue / saturation / intensity.

--- a/app/src/main/res/values-ja/strings_common.xml
+++ b/app/src/main/res/values-ja/strings_common.xml
@@ -68,6 +68,8 @@
     <!-- Why the array is being held dark -->
     <!-- "Quiet hours" -->
     <string name="suppression_quiet_hours">サイレント時間</string>
+    <!-- "Test blocked: %1$s" -->
+    <string name="test_blocked_by_guard">テストは実行できません：%1$s</string>
     <!-- "Low battery" -->
     <string name="suppression_low_battery">電池残量が少ない</string>
     <!-- "Battery Saver" — Android's own Japanese for the system feature -->

--- a/app/src/main/res/values-ja/strings_setup.xml
+++ b/app/src/main/res/values-ja/strings_setup.xml
@@ -11,6 +11,12 @@
 -->
 <resources>
 
+    <!-- Compact project attribution at the top of Settings. -->
+    <!-- "Made with passion and care by Dhananjay Tech" -->
+    <string name="setup_attribution">Dhananjay Tech が情熱と心を込めて作りました</string>
+    <!-- "Opens Dhananjay Tech on X" -->
+    <string name="setup_attribution_external">X で Dhananjay Tech を開きます</string>
+
     <!-- Auto-off -->
     <!-- "Auto-off" -->
     <string name="setup_auto_off_title">自動オフ</string>
@@ -36,9 +42,11 @@
          the phone sleeps. You can turn this back down at any time." -->
     <string name="setup_warn_long_confirm_body">最大 5 分の連続点灯は電池を消費します。端末がスリープに入るとアニメーションは点灯したまま停止します。設定はいつでも戻せます。</string>
 
-    <!-- When to stay dark -->
-    <!-- "When to stay dark" -->
-    <string name="setup_dark_title">消灯する条件</string>
+    <!-- Conditions that enable a glow are distinct from conditions that pause output. -->
+    <!-- "When HiLight can glow" -->
+    <string name="setup_glow_conditions_title">HiLight が点灯できる条件</string>
+    <!-- "When HiLight should pause" -->
+    <string name="setup_pause_conditions_title">HiLight を一時停止する条件</string>
     <!-- "Only while the screen is off" -->
     <string name="setup_screen_off_only">画面消灯時のみ</string>
     <!-- "Only while the phone is face down" -->
@@ -229,6 +237,8 @@
     <string name="setup_test_delay_button">5 秒後に送信</string>
     <!-- "Posting in %1$ds…" -->
     <string name="setup_test_countdown">あと%1$d秒で送信…</string>
+    <!-- "HiLight is off. Turn it on before posting a test notification." -->
+    <string name="setup_test_blocked_hilight_off">HiLight はオフです。テスト通知を送る前にオンにしてください。</string>
     <!-- "Self test" -->
     <string name="setup_selftest_channel">セルフテスト</string>
     <!-- "HiLight self test" -->

--- a/app/src/main/res/values/strings_common.xml
+++ b/app/src/main/res/values/strings_common.xml
@@ -46,6 +46,7 @@
 
     <!-- Why the array is being held dark -->
     <string name="suppression_quiet_hours">Quiet hours</string>
+    <string name="test_blocked_by_guard">Test blocked: %1$s</string>
     <string name="suppression_low_battery">Low battery</string>
     <string name="suppression_power_saver">Battery Saver</string>
     <string name="suppression_screen_on">Screen-off only</string>

--- a/app/src/main/res/values/strings_setup.xml
+++ b/app/src/main/res/values/strings_setup.xml
@@ -12,6 +12,10 @@
 -->
 <resources>
 
+    <!-- Compact project attribution at the top of Settings. The whole card opens the profile. -->
+    <string name="setup_attribution">Made with passion and care by Dhananjay Tech</string>
+    <string name="setup_attribution_external">Opens Dhananjay Tech on X</string>
+
     <!-- Auto-off. The trailing readout and the slider badge both come from the shared duration
          strings, so only the prose is here. -->
     <string name="setup_auto_off_title">Auto-off</string>
@@ -27,9 +31,9 @@
     <string name="setup_warn_long_confirm_title">Are you sure?</string>
     <string name="setup_warn_long_confirm_body">Up to 5 minutes of continuous illumination will cost battery, and animations freeze lit if the phone sleeps. You can turn this back down at any time.</string>
 
-    <!-- When to stay dark. The "Quiet hours" toggle reuses suppression_quiet_hours, which is the
-         same words said of the same thing. -->
-    <string name="setup_dark_title">When to stay dark</string>
+    <!-- Conditions that enable a glow are distinct from conditions that pause output. -->
+    <string name="setup_glow_conditions_title">When HiLight can glow</string>
+    <string name="setup_pause_conditions_title">When HiLight should pause</string>
     <string name="setup_screen_off_only">Only while the screen is off</string>
     <string name="setup_face_down_only">Only while the phone is face down</string>
     <!-- Both take a 24-hour clock time, which is formatted in code because it carries no words. -->
@@ -143,6 +147,7 @@
     <string name="setup_test_button">Post test notification</string>
     <string name="setup_test_delay_button">Post in 5 seconds</string>
     <string name="setup_test_countdown">Posting in %1$ds…</string>
+    <string name="setup_test_blocked_hilight_off">HiLight is off. Turn it on before posting a test notification.</string>
     <string name="setup_selftest_channel">Self test</string>
     <string name="setup_selftest_title">HiLight self test</string>
     <string name="setup_selftest_body">If a rule exists for this app, the LEDs just fired</string>

--- a/app/src/test/java/com/hilight/studio/GuardStateTest.kt
+++ b/app/src/test/java/com/hilight/studio/GuardStateTest.kt
@@ -55,6 +55,40 @@ class GuardStateTest {
             Suppression.LOW_BATTERY,
             batteryGate.outputSuppression(true, AlertSource.PREVIEW),
         )
+        assertNull(faceGate.previewSuppressionReason())
+        assertEquals(Suppression.LOW_BATTERY, batteryGate.previewSuppressionReason())
+    }
+
+    @Test
+    fun `preview warnings cover quiet hours saver and low battery`() {
+        assertEquals(
+            Suppression.QUIET_HOURS,
+            GuardState(quietEnabled = true, inQuietWindow = true).previewSuppressionReason(),
+        )
+        assertEquals(
+            Suppression.POWER_SAVER,
+            GuardState(powerSaveMode = true).previewSuppressionReason(),
+        )
+        assertEquals(
+            Suppression.LOW_BATTERY,
+            GuardState(batteryPct = 1).previewSuppressionReason(),
+        )
+        assertNull(
+            GuardState(
+                quietEnabled = true,
+                quietDim = true,
+                inQuietWindow = true,
+            ).previewSuppressionReason(),
+        )
+    }
+
+    @Test
+    fun `settings suppression reasons route to their owning section`() {
+        assertEquals(SettingsSuppressionSection.GLOW, Suppression.SCREEN_ON.settingsSection())
+        assertEquals(SettingsSuppressionSection.GLOW, Suppression.NOT_FACE_DOWN.settingsSection())
+        assertEquals(SettingsSuppressionSection.PAUSE, Suppression.QUIET_HOURS.settingsSection())
+        assertEquals(SettingsSuppressionSection.PAUSE, Suppression.POWER_SAVER.settingsSection())
+        assertEquals(SettingsSuppressionSection.PAUSE, Suppression.LOW_BATTERY.settingsSection())
     }
 
     @Test
@@ -139,6 +173,7 @@ class GuardStateTest {
         val s = GuardState(screenOffOnly = true, screenOn = true)
         assertEquals(Suppression.SCREEN_ON, s.suppression())
         assertNull(s.alertSuppression())
+        assertNull(s.outputSuppression(true, AlertSource.NOTIFICATION))
     }
 
     @Test

--- a/app/src/test/java/com/hilight/studio/ScreenLifecycleDecisionTest.kt
+++ b/app/src/test/java/com/hilight/studio/ScreenLifecycleDecisionTest.kt
@@ -1,0 +1,65 @@
+package com.hilight.studio
+
+import android.content.Intent
+import android.os.PowerManager
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ScreenLifecycleDecisionTest {
+
+    @Test
+    fun `screen off arms and refreshes`() {
+        assertEquals(
+            ScreenLifecycleAction.ARM_AND_REFRESH,
+            screenLifecycleAction(Intent.ACTION_SCREEN_OFF, alertScreenOffGated = false),
+        )
+    }
+
+    @Test
+    fun `ordinary alert survives screen wake`() {
+        assertEquals(
+            ScreenLifecycleAction.REFRESH_ONLY,
+            screenLifecycleAction(Intent.ACTION_SCREEN_ON, alertScreenOffGated = false),
+        )
+    }
+
+    @Test
+    fun `screen off gated alert stops on screen wake`() {
+        assertEquals(
+            ScreenLifecycleAction.CANCEL_AND_REFRESH,
+            screenLifecycleAction(Intent.ACTION_SCREEN_ON, alertScreenOffGated = true),
+        )
+    }
+
+    @Test
+    fun `unlock stops every alert`() {
+        assertEquals(
+            ScreenLifecycleAction.CANCEL_AND_REFRESH,
+            screenLifecycleAction(Intent.ACTION_USER_PRESENT, alertScreenOffGated = false),
+        )
+        assertEquals(
+            ScreenLifecycleAction.CANCEL_AND_REFRESH,
+            screenLifecycleAction(Intent.ACTION_USER_PRESENT, alertScreenOffGated = true),
+        )
+    }
+
+    @Test
+    fun `power changes only refresh guards`() {
+        assertEquals(
+            ScreenLifecycleAction.REFRESH_ONLY,
+            screenLifecycleAction(Intent.ACTION_POWER_CONNECTED, alertScreenOffGated = false),
+        )
+        assertEquals(
+            ScreenLifecycleAction.REFRESH_ONLY,
+            screenLifecycleAction(PowerManager.ACTION_POWER_SAVE_MODE_CHANGED, false),
+        )
+    }
+
+    @Test
+    fun `missing broadcast action only refreshes guards`() {
+        assertEquals(
+            ScreenLifecycleAction.REFRESH_ONLY,
+            screenLifecycleAction(action = null, alertScreenOffGated = true),
+        )
+    }
+}

--- a/docs/i18n/ja-review.md
+++ b/docs/i18n/ja-review.md
@@ -48,6 +48,7 @@ Leave Latin as-is: HiLight, Shizuku, ADB, LED, JSON, MessagingStyle, shortcutId,
 | `cycle_wave` | One wave travelling once across the array. | 波が LED アレイを 1 回横切ります。 |
 | `cycle_rainbow` | One trip through every hue, back to the start. | すべての色相を一巡して元に戻ります。 |
 | `suppression_quiet_hours` | Quiet hours | サイレント時間 |
+| `test_blocked_by_guard` | Test blocked: %1$s | テストは実行できません：%1$s |
 | `suppression_low_battery` | Low battery | 電池残量が少ない |
 | `suppression_power_saver` | Battery Saver | バッテリーセーバー |
 | `suppression_screen_on` | Screen-off only | 画面消灯時のみ |
@@ -250,6 +251,8 @@ Leave Latin as-is: HiLight, Shizuku, ADB, LED, JSON, MessagingStyle, shortcutId,
 
 | name | English | Japanese |
 |---|---|---|
+| `setup_attribution` | Made with passion and care by Dhananjay Tech | Dhananjay Tech が情熱と心を込めて作りました |
+| `setup_attribution_external` | Opens Dhananjay Tech on X | X で Dhananjay Tech を開きます |
 | `setup_auto_off_title` | Auto-off | 自動オフ |
 | `setup_auto_off_body` | The always-on look switches itself off after this. App rules still work. | 常時点灯スタイルはこの時間が過ぎると自動でオフになります。アプリ別ルールはそのまま動作します。 |
 | `setup_auto_off_protection` | Hardware protection is always on: brightness eases down after 10s of unbroken light, and the array rests if it has been lit for more than half of the last 10 minutes. | ハードウェア保護は常に有効です。10 秒続けて点灯すると明るさが徐々に下がり、直近 10 分のうち半分以上点灯していた場合は LED アレイが休止します。 |
@@ -259,7 +262,8 @@ Leave Latin as-is: HiLight, Shizuku, ADB, LED, JSON, MessagingStyle, shortcutId,
 | `setup_warn_long_body` | The LEDs draw power the whole time they are lit, and stock HiLight only flashes for a moment — nothing about the hardware is built for minutes of continuous light. | LED は点灯している間ずっと電力を消費します。標準の HiLight は一瞬光るだけで、このハードウェアは数分間の連続点灯を想定して作られていません。 |
 | `setup_warn_long_confirm_title` | Are you sure? | 本当に設定しますか |
 | `setup_warn_long_confirm_body` | Up to 5 minutes of continuous illumination will cost battery, and animations freeze lit if the phone sleeps. You can turn this back down at any time. | 最大 5 分の連続点灯は電池を消費します。端末がスリープに入るとアニメーションは点灯したまま停止します。設定はいつでも戻せます。 |
-| `setup_dark_title` | When to stay dark | 消灯する条件 |
+| `setup_glow_conditions_title` | When HiLight can glow | HiLight が点灯できる条件 |
+| `setup_pause_conditions_title` | When HiLight should pause | HiLight を一時停止する条件 |
 | `setup_screen_off_only` | Only while the screen is off | 画面消灯時のみ |
 | `setup_quiet_from` | From %1$s | 開始 %1$s |
 | `setup_quiet_until` | Until %1$s | 終了 %1$s |
@@ -340,6 +344,7 @@ Leave Latin as-is: HiLight, Shizuku, ADB, LED, JSON, MessagingStyle, shortcutId,
 | `setup_test_title` | End-to-end test | 通し動作テスト |
 | `setup_test_body` | Posts a notification from this app. Add a rule for HiLight Studio first. | このアプリから通知を送信します。先に HiLight Studio のルールを追加してください。 |
 | `setup_test_button` | Post test notification | テスト通知を送信 |
+| `setup_test_blocked_hilight_off` | HiLight is off. Turn it on before posting a test notification. | HiLight はオフです。テスト通知を送る前にオンにしてください。 |
 | `setup_selftest_channel` | Self test | セルフテスト |
 | `setup_selftest_title` | HiLight self test | HiLight セルフテスト |
 | `setup_selftest_body` | If a rule exists for this app, the LEDs just fired | このアプリのルールがあれば、今 LED が点灯しました |


### PR DESCRIPTION
## Summary

- keep ordinary notification alerts alive when the notification wakes the screen, while preserving unlock, face-down, expiry, and per-rule screen-off cancellation
- explain when previews or the notification self-test are blocked without adding new controls
- split Settings into clear glow and pause sections and add the requested Dhananjay Tech attribution card
- bump the release candidate to version 1.0.11 / versionCode 12

## Verification

- `./gradlew --no-daemon :app:testDebugUnitTest :app:build :app:lint`
- `./scripts/build-helper.sh`
- permanent-key signed release verified with `apksigner`
- reviewed before and after implementation by Claude Code Opus 5 at Extra High effort; final verdict `CONSENSUS_STATUS: AGREE`

## Hardware boundary

The lifecycle change matches issue #32's first-alert sequence, but remains a hypothesis until the affected Pixel 11 Pro reporter confirms it. Renderer cleanup and OutputGate behavior are unchanged.
