### PR TITLE
feat: export app rules

### DIFF
--- a/app/src/main/java/com/hilight/studio/AppRulesScreen.kt
+++ b/app/src/main/java/com/hilight/studio/AppRulesScreen.kt
@@ -55,6 +55,7 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -99,6 +100,8 @@ fun AppRulesScreen(store: Store) {
     var choosingPrivacyActivity by remember { mutableStateOf(false) }
     var privacyPrefilledApp by remember { mutableStateOf<InstalledApp?>(null) }
     var pickingPrivacyAppFor by remember { mutableStateOf<PrivacyActivity?>(null) }
+    var importing by remember { mutableStateOf(false) }
+    var importText by remember { mutableStateOf("") }
     val learnedPackages = remember(conversations) {
         conversations.mapTo(mutableSetOf()) { it.pkg }
     }
@@ -120,6 +123,17 @@ fun AppRulesScreen(store: Store) {
             Icon(Icons.Rounded.Add, contentDescription = null)
             Spacer(Modifier.width(8.dp))
             ButtonLabel(stringResource(R.string.rules_add))
+        }
+        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+            FilledTonalButton(
+                onClick = { shareRules(ctx, store.exportRules()) },
+                enabled = rules.isNotEmpty(),
+                modifier = Modifier.weight(1f),
+            ) { ButtonLabel(stringResource(R.string.rules_export)) }
+            FilledTonalButton(
+                onClick = { importText = ""; importing = true },
+                modifier = Modifier.weight(1f),
+            ) { ButtonLabel(stringResource(R.string.rules_import)) }
         }
     }
 
@@ -320,6 +334,50 @@ fun AppRulesScreen(store: Store) {
             onTest = { store.preview(it.pattern, it.color, it.speedMs, it.brightness, it.lightMs) },
         )
     }
+
+    if (importing) {
+        AlertDialog(
+            onDismissRequest = { importing = false },
+            shape = MaterialTheme.shapes.extraLarge,
+            title = { Text(stringResource(R.string.rules_paste_exported)) },
+            text = {
+                OutlinedTextField(
+                    value = importText,
+                    onValueChange = { importText = it },
+                    label = { Text(stringResource(R.string.rules_import_json_field)) },
+                    modifier = Modifier.heightIn(max = 220.dp),
+                )
+            },
+            confirmButton = {
+                val res = LocalResources.current
+                TextButton(onClick = {
+                    val added = store.importRules(importText)
+                    Toast.makeText(
+                        ctx,
+                        if (added == null) res.getString(R.string.rules_import_failed)
+                        else res.getString(R.string.rules_import_count, added),
+                        Toast.LENGTH_SHORT,
+                    ).show()
+                    importing = false
+                }) { ButtonLabel(stringResource(R.string.rules_import)) }
+            },
+            dismissButton = {
+                TextButton(onClick = { importing = false }) {
+                    ButtonLabel(stringResource(R.string.common_cancel))
+                }
+            },
+        )
+    }
+}
+
+private fun shareRules(ctx: android.content.Context, text: String) {
+    val send = Intent(Intent.ACTION_SEND).apply {
+        type = "text/plain"
+        putExtra(Intent.EXTRA_TEXT, text)
+    }
+    ctx.startActivity(
+        Intent.createChooser(send, ctx.getString(R.string.rules_export_chooser))
+    )
 }
 
 /**

--- a/app/src/main/res/values-ja/strings_rules.xml
+++ b/app/src/main/res/values-ja/strings_rules.xml
@@ -35,6 +35,20 @@
     <string name="rules_intro_messaging">メッセージアプリではもう一歩進んで、特定の連絡先やチャットだけに色を設定できます。</string>
     <!-- "Add app rule" -->
     <string name="rules_add">アプリ別ルールを追加</string>
+    <!-- "Export" -->
+    <string name="rules_export">書き出し</string>
+    <!-- "Import" -->
+    <string name="rules_import">読み込み</string>
+    <!-- "Export app rules" -->
+    <string name="rules_export_chooser">アプリ別ルールを書き出す</string>
+    <!-- "Paste exported rules" -->
+    <string name="rules_paste_exported">書き出したルールを貼り付け</string>
+    <!-- "JSON" -->
+    <string name="rules_import_json_field">JSON</string>
+    <!-- "That JSON could not be read" -->
+    <string name="rules_import_failed">その JSON を読み込めませんでした</string>
+    <!-- "Imported %1$d" -->
+    <string name="rules_import_count">%1$d 件を読み込みました</string>
 
     <!-- One rule card. The summary line is "pattern · when it fires". The short trigger phrases are
          lower case in English and capitalised in the editor's selector; Japanese has no case, so the

--- a/app/src/main/res/values/strings_rules.xml
+++ b/app/src/main/res/values/strings_rules.xml
@@ -20,6 +20,13 @@
     <string name="rules_intro_apps">Choose an app, then what HiLight does when it notifies you — or while it is open.</string>
     <string name="rules_intro_messaging">Messaging apps go one step further: a colour for a single contact or chat.</string>
     <string name="rules_add">Add app rule</string>
+    <string name="rules_export">Export</string>
+    <string name="rules_import">Import</string>
+    <string name="rules_export_chooser">Export app rules</string>
+    <string name="rules_paste_exported">Paste exported rules</string>
+    <string name="rules_import_json_field">JSON</string>
+    <string name="rules_import_failed">That JSON could not be read</string>
+    <string name="rules_import_count">Imported %1$d</string>
 
     <!-- One rule card. The summary line is "pattern · when it fires": %1$s is a pattern name from
          strings_common.xml or rules_random_colour, %2$s one of the two trigger phrases below. Those

--- a/app/src/test/java/com/hilight/studio/AppRulePersistenceTest.kt
+++ b/app/src/test/java/com/hilight/studio/AppRulePersistenceTest.kt
@@ -1,7 +1,10 @@
 package com.hilight.studio
 
 import org.json.JSONObject
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -27,4 +30,128 @@ class AppRulePersistenceTest {
 
         assertFalse(AppRule.fromJson(legacy).onlyWhenFaceDown)
     }
+
+    @Test
+    fun `exportRulesDocument produces valid json with version and rules`() {
+        val rule1 = AppRule(
+            pkg = "com.example.chat",
+            label = "ChatApp",
+            trigger = Trigger.NOTIFICATION,
+            pattern = Pattern.BREATHE,
+            color = 0xFF123456.toInt(),
+            durationMs = 15_000,
+            conversationKey = "chat123",
+            conversationName = "Alice",
+        )
+        val rule2 = AppRule(
+            pkg = "com.example.mail",
+            label = "MailApp",
+            trigger = Trigger.FOREGROUND,
+            pattern = Pattern.RAINBOW,
+        )
+
+        val exported = exportRulesDocument(listOf(rule1, rule2))
+        val json = JSONObject(exported)
+
+        assertEquals(1, json.getInt("v"))
+        val arr = json.getJSONArray("rules")
+        assertEquals(2, arr.length())
+
+        val parsed1 = AppRule.fromJson(arr.getJSONObject(0))
+        assertEquals("com.example.chat", parsed1.pkg)
+        assertEquals("ChatApp", parsed1.label)
+        assertEquals(Trigger.NOTIFICATION, parsed1.trigger)
+        assertEquals(Pattern.BREATHE, parsed1.pattern)
+        assertEquals(0xFF123456.toInt(), parsed1.color)
+        assertEquals(15_000, parsed1.durationMs)
+        assertEquals("chat123", parsed1.conversationKey)
+        assertEquals("Alice", parsed1.conversationName)
+
+        val parsed2 = AppRule.fromJson(arr.getJSONObject(1))
+        assertEquals("com.example.mail", parsed2.pkg)
+        assertEquals(Trigger.FOREGROUND, parsed2.trigger)
+        assertEquals(Pattern.RAINBOW, parsed2.pattern)
+    }
+
+    @Test
+    fun `parseImportedRules parses versioned object and raw array format`() {
+        val rule = AppRule(
+            pkg = "com.example.app",
+            label = "TestApp",
+            trigger = Trigger.NOTIFICATION,
+            pattern = Pattern.COMET,
+        )
+        val exported = exportRulesDocument(listOf(rule))
+
+        val parsedFromObject = parseImportedRules(exported)
+        assertNotNull(parsedFromObject)
+        assertEquals(1, parsedFromObject?.size)
+        assertEquals(rule.id, parsedFromObject?.first()?.id)
+
+        // Raw array format
+        val rawArray = JSONObject(exported).getJSONArray("rules").toString()
+        val parsedFromArray = parseImportedRules(rawArray)
+        assertNotNull(parsedFromArray)
+        assertEquals(1, parsedFromArray?.size)
+        assertEquals(rule.id, parsedFromArray?.first()?.id)
+    }
+
+    @Test
+    fun `parseImportedRules returns null on invalid or unparseable input`() {
+        assertNull(parseImportedRules("not valid json"))
+        assertNull(parseImportedRules("{}"))
+        assertNull(parseImportedRules("""{"rules": [{"invalid": true}]}"""))
+        assertNull(parseImportedRules("""[{"invalid": true}]"""))
+    }
+
+    @Test
+    fun `parseImportedRules returns empty list for empty rules array`() {
+        val result = parseImportedRules("""{"v": 1, "rules": []}""")
+        assertNotNull(result)
+        assertTrue(result?.isEmpty() == true)
+
+        val arrayResult = parseImportedRules("[]")
+        assertNotNull(arrayResult)
+        assertTrue(arrayResult?.isEmpty() == true)
+    }
+
+    @Test
+    fun `mergeImportedRules updates existing rule in place and preserves list order`() {
+        val existing1 = AppRule(pkg = "com.app.one", label = "One", color = 0x111111)
+        val existing2 = AppRule(pkg = "com.app.two", label = "Two", color = 0x222222)
+        val updated2 = existing2.copy(color = 0x999999, pattern = Pattern.CHASE)
+
+        val merged = mergeImportedRules(listOf(existing1, existing2), listOf(updated2))
+
+        assertEquals(2, merged.size)
+        assertEquals(existing1.id, merged[0].id)
+        assertEquals(0x111111, merged[0].color)
+        assertEquals(existing2.id, merged[1].id)
+        assertEquals(0x999999, merged[1].color)
+        assertEquals(Pattern.CHASE, merged[1].pattern)
+    }
+
+    @Test
+    fun `mergeImportedRules appends new rules at the end`() {
+        val existing1 = AppRule(pkg = "com.app.one", label = "One")
+        val newRule = AppRule(pkg = "com.app.new", label = "New")
+
+        val merged = mergeImportedRules(listOf(existing1), listOf(newRule))
+
+        assertEquals(2, merged.size)
+        assertEquals("com.app.one", merged[0].pkg)
+        assertEquals("com.app.new", merged[1].pkg)
+    }
+
+    @Test
+    fun `mergeImportedRules deduplicates incoming rules with same id`() {
+        val incoming1 = AppRule(pkg = "com.app.one", label = "One", color = 0x111111)
+        val incoming2 = AppRule(pkg = "com.app.one", label = "One", color = 0x222222)
+
+        val merged = mergeImportedRules(emptyList(), listOf(incoming1, incoming2))
+
+        assertEquals(1, merged.size)
+        assertEquals(0x222222, merged[0].color)
+    }
 }
+

--- a/docs/i18n/ja-review.md
+++ b/docs/i18n/ja-review.md
@@ -170,6 +170,13 @@ Leave Latin as-is: HiLight, Shizuku, ADB, LED, JSON, MessagingStyle, shortcutId,
 | `rules_intro_apps` | Choose an app, then what HiLight does when it notifies you — or while it is open. | アプリを選び、そのアプリから通知が届いたとき、またはアプリ表示中に HiLight が何をするかを設定します。 |
 | `rules_intro_messaging` | Messaging apps go one step further: a colour for a single contact or chat. | メッセージアプリではもう一歩進んで、特定の連絡先やチャットだけに色を設定できます。 |
 | `rules_add` | Add app rule | アプリ別ルールを追加 |
+| `rules_export` | Export | 書き出し |
+| `rules_import` | Import | 読み込み |
+| `rules_export_chooser` | Export app rules | アプリ別ルールを書き出す |
+| `rules_paste_exported` | Paste exported rules | 書き出したルールを貼り付け |
+| `rules_import_json_field` | JSON | JSON |
+| `rules_import_failed` | That JSON could not be read | その JSON を読み込めませんでした |
+| `rules_import_count` | Imported %1$d | %1$d 件を読み込みました |
 | `rules_card_summary` | %1$s · %2$s | %1$s · %2$s |
 | `rules_random_colour` | Random colour | ランダムな色 |
 | `rules_trigger_notification_short` | on notification | 通知時 |


### PR DESCRIPTION
## Summary

<!-- Describe the user-visible change and why it belongs here. -->
exports app rules so they can be imported later on after an app reinstall or factory reset

## Verification

- [x] `./gradlew :app:testDebugUnitTest :app:build :app:lint`
- [x] Tested on a supported Pixel device, if renderer, transport, or timing changed
- [x] No notification contents or other personal data are included
